### PR TITLE
fix: honor telemetry config opt-out

### DIFF
--- a/docs/features/telemetry.mdx
+++ b/docs/features/telemetry.mdx
@@ -22,7 +22,22 @@ Mobilerun collects <b>anonymized</b> usage data to help us understand which feat
 
 ## How to Disable Telemetry
 
-You can disable telemetry at any time by setting the following environment variable:
+Disable telemetry for an agent in Python:
+
+```python
+from mobilerun import MobileConfig, TelemetryConfig
+
+config = MobileConfig(telemetry=TelemetryConfig(enabled=False))
+```
+
+Or set the equivalent value in your YAML configuration:
+
+```yaml
+telemetry:
+  enabled: false
+```
+
+You can also disable telemetry for every Mobilerun process in your environment:
 
 ```bash
 export MOBILERUN_TELEMETRY_ENABLED=false
@@ -39,7 +54,12 @@ export MOBILERUN_TELEMETRY_ENABLED=true
 ```
 
 <Note>
-Telemetry is currently controlled only by the `MOBILERUN_TELEMETRY_ENABLED` environment variable. While a `telemetry.enabled` config option exists in the configuration schema, it is not currently used by the telemetry system.
+Telemetry is sent only when both `telemetry.enabled` and the environment setting
+allow it. An explicit `false` in either place always disables telemetry, so an
+environment value of `true` cannot override `telemetry.enabled: false`.
+
+`DROIDRUN_TELEMETRY_ENABLED` remains supported as a legacy fallback when
+`MOBILERUN_TELEMETRY_ENABLED` is not set.
 </Note>
 
 ---

--- a/docs/features/telemetry.mdx
+++ b/docs/features/telemetry.mdx
@@ -57,9 +57,6 @@ export MOBILERUN_TELEMETRY_ENABLED=true
 Telemetry is sent only when both `telemetry.enabled` and the environment setting
 allow it. An explicit `false` in either place always disables telemetry, so an
 environment value of `true` cannot override `telemetry.enabled: false`.
-
-`DROIDRUN_TELEMETRY_ENABLED` remains supported as a legacy fallback when
-`MOBILERUN_TELEMETRY_ENABLED` is not set.
 </Note>
 
 ---

--- a/mobilerun/agent/droid/droid_agent.py
+++ b/mobilerun/agent/droid/droid_agent.py
@@ -18,6 +18,18 @@ from llama_index.core.workflow import Context, StartEvent, StopEvent, Workflow, 
 from mobilerun_core_local.driver.android import AndroidDriver
 from mobilerun_core_local.driver.android.portal import ensure_portal_ready
 from mobilerun_core_local.driver.base import DeviceDisconnectedError
+from mobilerun_core_local.driver.ios import (
+    IOSPortalHttpDriver,
+    create_ios_driver,
+    discover_ios_device,
+)
+from mobilerun_core_local.driver.recording import RecordingDriver
+from mobilerun_core_local.driver.stealth import StealthDriver
+from mobilerun_core_local.driver.visual_remote import (
+    VISUAL_REMOTE_CONNECTION,
+    VISUAL_REMOTE_DEFAULT_URL,
+    VisualRemoteDriver,
+)
 from opentelemetry import trace
 from pydantic import BaseModel
 from workflows.events import Event
@@ -80,18 +92,6 @@ from mobilerun.telemetry import (
     MobileAgentInitEvent,
     capture,
     flush,
-)
-from mobilerun_core_local.driver.ios import (
-    IOSPortalHttpDriver,
-    create_ios_driver,
-    discover_ios_device,
-)
-from mobilerun_core_local.driver.recording import RecordingDriver
-from mobilerun_core_local.driver.stealth import StealthDriver
-from mobilerun_core_local.driver.visual_remote import (
-    VISUAL_REMOTE_CONNECTION,
-    VISUAL_REMOTE_DEFAULT_URL,
-    VisualRemoteDriver,
 )
 from mobilerun.tools.filters import ConciseFilter, DetailedFilter
 from mobilerun.tools.formatters import IndexedFormatter
@@ -256,6 +256,7 @@ class MobileAgent(Workflow):
             external_agents=config.external_agents if config else {},
             mcp=config.mcp if config else MCPConfig(),
         )
+        self.shared_state.telemetry_config_enabled = self.config.telemetry.enabled
         control_backend = _normalize_control_backend(
             self.resolved_device_config.control_backend
         )
@@ -749,6 +750,7 @@ class MobileAgent(Workflow):
                 custom_prompts=self._init_prompts,
             ),
             self.user_id,
+            config_enabled=self.shared_state.telemetry_config_enabled,
         )
 
         if self.config.logging.save_trajectory != "none":
@@ -1011,8 +1013,9 @@ class MobileAgent(Workflow):
                 unique_activities_count=len(self.shared_state.visited_activities),
             ),
             self.user_id,
+            config_enabled=self.shared_state.telemetry_config_enabled,
         )
-        await flush()
+        await flush(config_enabled=self.shared_state.telemetry_config_enabled)
 
         # Base result with answer
         result = ResultEvent(

--- a/mobilerun/agent/droid/state.py
+++ b/mobilerun/agent/droid/state.py
@@ -26,6 +26,7 @@ class MobileAgentState(BaseModel):
     step_number: int = 0
     runtype: str = "developer"
     user_id: str | None = None
+    telemetry_config_enabled: bool = Field(default=True, exclude=True)
     platform: str = "Android"
 
     # ========================================================================
@@ -192,6 +193,7 @@ class MobileAgentState(BaseModel):
                 step_number=self.step_number,
             ),
             user_id=self.user_id,
+            config_enabled=self.telemetry_config_enabled,
         )
 
 

--- a/mobilerun/cli/device_commands.py
+++ b/mobilerun/cli/device_commands.py
@@ -16,15 +16,15 @@ import click
 from async_adbutils import adb
 from mobilerun_core_local.driver.android import AndroidDriver
 from mobilerun_core_local.driver.android.portal import ensure_portal_ready
-from rich.console import Console
-
-from mobilerun.config_manager import ConfigLoader
 from mobilerun_core_local.driver.ios import (
     IOSPortalHttpDriver,
     create_ios_driver,
     discover_ios_device,
     validate_ios_portal_url,
 )
+from rich.console import Console
+
+from mobilerun.config_manager import ConfigLoader
 from mobilerun.tools.filters import ConciseFilter
 from mobilerun.tools.formatters import IndexedFormatter
 from mobilerun.tools.ui.ios_provider import IOSStateProvider

--- a/mobilerun/cli/main.py
+++ b/mobilerun/cli/main.py
@@ -27,6 +27,8 @@ from mobilerun_core_local.driver.android.portal import (
     ping_portal_tcp,
     setup_portal,
 )
+from mobilerun_core_local.driver.ios import discover_ios_device, validate_ios_portal_url
+from mobilerun_core_local.driver.visual_remote import VISUAL_REMOTE_CONNECTION
 from rich.console import Console
 from rich.panel import Panel
 from rich.text import Text
@@ -67,8 +69,6 @@ from mobilerun.config_manager.credential_paths import (
 from mobilerun.log_handlers import CLILogHandler, configure_logging
 from mobilerun.macro.cli import macro_cli
 from mobilerun.telemetry import print_telemetry_message
-from mobilerun_core_local.driver.ios import discover_ios_device, validate_ios_portal_url
-from mobilerun_core_local.driver.visual_remote import VISUAL_REMOTE_CONNECTION
 
 # Suppress all warnings
 warnings.filterwarnings("ignore")
@@ -171,7 +171,7 @@ async def run_command(
 
     try:
         logger.info(f"🚀 Starting: {command}")
-        print_telemetry_message()
+        print_telemetry_message(config_enabled=config.telemetry.enabled)
 
         # ================================================================
         # STEP 1: Apply CLI overrides via direct mutation
@@ -1330,7 +1330,7 @@ async def test(
 
     try:
         logger.info(f"🚀 Starting: {command}")
-        print_telemetry_message()
+        print_telemetry_message(config_enabled=config.telemetry.enabled)
 
         # ================================================================
         # STEP 1: Apply CLI overrides via direct mutation

--- a/mobilerun/telemetry/tracker.py
+++ b/mobilerun/telemetry/tracker.py
@@ -2,13 +2,15 @@
 Anonymous telemetry tracking using PostHog.
 
 This module handles opt-in telemetry collection to help improve Mobilerun.
-All data is anonymized and can be disabled by setting DROIDRUN_TELEMETRY_ENABLED=false.
+All data is anonymized, and telemetry can be disabled through the Mobilerun
+configuration or environment variables.
 """
 
 import asyncio
 import logging
 import os
 from pathlib import Path
+from threading import Lock
 from uuid import UUID, uuid4
 
 from posthog import Posthog
@@ -24,51 +26,53 @@ USER_ID_PATH = Path.home() / ".droidrun" / "user_id"
 RUN_ID = str(uuid4())
 
 TELEMETRY_ENABLED_MESSAGE = "Anonymized telemetry enabled. See https://docs.mobilerun.ai/v3/guides/telemetry for more information."
-TELEMETRY_DISABLED_MESSAGE = "🛑 Anonymized telemetry disabled. Consider setting the DROIDRUN_TELEMETRY_ENABLED environment variable to 'true' to enable telemetry and help us improve Mobilerun."
+TELEMETRY_DISABLED_MESSAGE = "🛑 Anonymized telemetry disabled. Telemetry can be controlled through Mobilerun configuration or the MOBILERUN_TELEMETRY_ENABLED environment variable."
 
 # Created lazily on first capture/flush. Constructing the PostHog client spawns
 # a consumer thread and registers a blocking atexit flush, which added ~5s to
 # the shutdown of EVERY command (incl. `mobilerun --help`) because importing
 # mobilerun imports this module. Deferring it keeps non-telemetry commands fast.
 _posthog: Posthog | None = None
+_posthog_lock = Lock()
 
 
 def _get_posthog() -> Posthog:
     global _posthog
     if _posthog is None:
-        _posthog = Posthog(
-            project_api_key=PROJECT_API_KEY,
-            host=HOST,
-            disable_geoip=False,
-        )
+        with _posthog_lock:
+            if _posthog is None:
+                _posthog = Posthog(
+                    project_api_key=PROJECT_API_KEY,
+                    host=HOST,
+                    disable_geoip=False,
+                )
     return _posthog
 
 
-def is_telemetry_enabled():
+def is_telemetry_enabled(*, config_enabled: bool = True) -> bool:
     """
-    Check if telemetry is enabled via environment variable.
+    Check whether both configuration and environment policy enable telemetry.
 
     Returns:
-        True if DROIDRUN_TELEMETRY_ENABLED is set to true/1/yes/y (case-insensitive),
-        or if the environment variable is not set (default is enabled).
+        True when ``config_enabled`` is true and the primary or legacy telemetry
+        environment variable is true/1/yes/y (case-insensitive). Environment
+        policy defaults to enabled when neither variable is set.
     """
-    telemetry_enabled = (
-        os.environ.get("MOBILERUN_TELEMETRY_ENABLED")
-        or os.environ.get("DROIDRUN_TELEMETRY_ENABLED")
-        or "true"
-    )
-    enabled = telemetry_enabled.lower() in ["true", "1", "yes", "y"]
+    telemetry_enabled = os.environ.get("MOBILERUN_TELEMETRY_ENABLED")
+    if telemetry_enabled is None:
+        telemetry_enabled = os.environ.get("DROIDRUN_TELEMETRY_ENABLED") or "true"
+    enabled = config_enabled and telemetry_enabled.lower() in ["true", "1", "yes", "y"]
     logger.debug(f"Telemetry enabled: {enabled}")
     return enabled
 
 
-def print_telemetry_message():
+def print_telemetry_message(*, config_enabled: bool = True) -> None:
     """
     Print telemetry status message to the logger.
 
-    Displays enabled or disabled message based on DROIDRUN_TELEMETRY_ENABLED setting.
+    Displays the effective status based on configuration and environment policy.
     """
-    if is_telemetry_enabled():
+    if is_telemetry_enabled(config_enabled=config_enabled):
         mobilerun_logger.debug(TELEMETRY_ENABLED_MESSAGE)
 
     else:
@@ -124,21 +128,28 @@ def get_user_id() -> str:
         return "unknown"
 
 
-def capture(event: TelemetryEvent, user_id: str | None = None):
+def capture(
+    event: TelemetryEvent,
+    user_id: str | None = None,
+    *,
+    config_enabled: bool = True,
+) -> None:
     """
     Capture and send a telemetry event to PostHog.
 
     Args:
         event: Telemetry event to capture (must be a TelemetryEvent subclass)
         user_id: Optional user ID to use instead of the default persistent ID
+        config_enabled: Whether telemetry is enabled in Mobilerun configuration
 
     Note:
         This function is a no-op if telemetry is disabled.
     """
+    if not is_telemetry_enabled(config_enabled=config_enabled):
+        logger.debug(f"Telemetry disabled, skipping capture of {event}")
+        return
+
     try:
-        if not is_telemetry_enabled():
-            logger.debug(f"Telemetry disabled, skipping capture of {event}")
-            return
         event_name = type(event).__name__
         event_data = event.model_dump()
         properties = {
@@ -154,9 +165,9 @@ def capture(event: TelemetryEvent, user_id: str | None = None):
         logger.error(f"Error capturing event: {e}")
 
 
-async def flush():
+async def flush(*, config_enabled: bool = True) -> None:
     try:
-        if not is_telemetry_enabled() or _posthog is None:
+        if not is_telemetry_enabled(config_enabled=config_enabled) or _posthog is None:
             return
 
         await asyncio.wait_for(asyncio.to_thread(_posthog.flush), timeout=10)

--- a/mobilerun/tools/__init__.py
+++ b/mobilerun/tools/__init__.py
@@ -5,6 +5,7 @@ Mobilerun Tools - Public API.
 """
 
 from mobilerun_core_local.driver import AndroidDriver, DeviceDriver, RecordingDriver
+
 from mobilerun.tools.ui import AndroidStateProvider, StateProvider, UIState
 
 __all__ = [

--- a/tests/test_driver_reexports.py
+++ b/tests/test_driver_reexports.py
@@ -9,7 +9,10 @@ resolves to the exact same classes as the core packages.
 
 import unittest
 
+import mobilerun_core_local.driver.android
+import mobilerun_core_local.driver.base
 import mobilerun_core_local.driver.cloud
+import mobilerun_core_local.driver.ios
 import mobilerun_core_local.driver.recording
 import mobilerun_core_local.driver.stealth
 import mobilerun_core_local.driver.visual_remote
@@ -29,6 +32,30 @@ from mobilerun.tools.driver import (
 
 class DriverCompatIdentityTest(unittest.TestCase):
     """Compat names must be the exact same objects as the core implementations."""
+
+    def test_android_driver_is_core_local_implementation(self):
+        self.assertIs(
+            AndroidDriver,
+            mobilerun_core_local.driver.android.AndroidDriver,
+        )
+
+    def test_device_disconnected_error_is_core_local_implementation(self):
+        self.assertIs(
+            DeviceDisconnectedError,
+            mobilerun_core_local.driver.base.DeviceDisconnectedError,
+        )
+
+    def test_device_driver_is_core_local_implementation(self):
+        self.assertIs(
+            DeviceDriver,
+            mobilerun_core_local.driver.base.DeviceDriver,
+        )
+
+    def test_ios_driver_is_core_local_implementation(self):
+        self.assertIs(
+            IOSDriver,
+            mobilerun_core_local.driver.ios.IOSDriver,
+        )
 
     def test_recording_driver_is_core_local_implementation(self):
         self.assertIs(

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,358 @@
+import asyncio
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from mobilerun.telemetry import tracker
+from mobilerun.telemetry.events import PackageVisitEvent
+
+PRIMARY_TELEMETRY_ENV = "MOBILERUN_TELEMETRY_ENABLED"
+LEGACY_TELEMETRY_ENV = "DROIDRUN_TELEMETRY_ENABLED"
+
+
+def _package_visit_event() -> PackageVisitEvent:
+    return PackageVisitEvent(
+        package_name="com.example.settings",
+        activity_name=".MainActivity",
+        step_number=3,
+    )
+
+
+@pytest.fixture(autouse=True)
+def reset_telemetry_state(monkeypatch):
+    monkeypatch.delenv(PRIMARY_TELEMETRY_ENV, raising=False)
+    monkeypatch.delenv(LEGACY_TELEMETRY_ENV, raising=False)
+    monkeypatch.setattr(tracker, "_posthog", None)
+
+
+def test_telemetry_is_enabled_by_default(monkeypatch) -> None:
+    monkeypatch.delenv(PRIMARY_TELEMETRY_ENV, raising=False)
+    monkeypatch.delenv(LEGACY_TELEMETRY_ENV, raising=False)
+
+    assert tracker.is_telemetry_enabled() is True
+    assert tracker.is_telemetry_enabled(config_enabled=True) is True
+
+
+def test_config_false_disables_telemetry() -> None:
+    assert tracker.is_telemetry_enabled(config_enabled=False) is False
+
+
+def test_environment_false_disables_telemetry(monkeypatch) -> None:
+    monkeypatch.setenv(PRIMARY_TELEMETRY_ENV, "false")
+
+    assert tracker.is_telemetry_enabled() is False
+    assert tracker.is_telemetry_enabled(config_enabled=True) is False
+
+
+def test_config_false_wins_when_environment_is_true(monkeypatch) -> None:
+    monkeypatch.setenv(PRIMARY_TELEMETRY_ENV, "true")
+
+    assert tracker.is_telemetry_enabled(config_enabled=False) is False
+
+
+@pytest.mark.parametrize(
+    ("primary", "legacy", "expected"),
+    [
+        ("false", "true", False),
+        ("true", "false", True),
+        ("", "true", False),
+        (None, "false", False),
+        (None, "yes", True),
+    ],
+)
+def test_primary_environment_variable_takes_precedence_over_legacy(
+    monkeypatch, primary: str | None, legacy: str, expected: bool
+) -> None:
+    if primary is None:
+        monkeypatch.delenv(PRIMARY_TELEMETRY_ENV, raising=False)
+    else:
+        monkeypatch.setenv(PRIMARY_TELEMETRY_ENV, primary)
+    monkeypatch.setenv(LEGACY_TELEMETRY_ENV, legacy)
+
+    assert tracker.is_telemetry_enabled() is expected
+
+
+def test_disabled_capture_does_not_resolve_user_or_create_client(monkeypatch) -> None:
+    monkeypatch.setenv(PRIMARY_TELEMETRY_ENV, "true")
+    calls = []
+
+    def record_call(*args, **kwargs):
+        calls.append((args, kwargs))
+        raise AssertionError("disabled telemetry performed a side effect")
+
+    monkeypatch.setattr(tracker, "get_user_id", record_call)
+    monkeypatch.setattr(tracker, "_get_posthog", record_call)
+
+    tracker.capture(_package_visit_event(), config_enabled=False)
+
+    assert calls == []
+    assert tracker._posthog is None
+
+
+def test_disabled_flush_does_not_flush_an_existing_client(monkeypatch) -> None:
+    class FakePosthog:
+        def __init__(self):
+            self.flush_calls = 0
+
+        def flush(self) -> None:
+            self.flush_calls += 1
+
+    client = FakePosthog()
+    monkeypatch.setattr(tracker, "_posthog", client)
+    monkeypatch.setenv(PRIMARY_TELEMETRY_ENV, "true")
+
+    asyncio.run(tracker.flush(config_enabled=False))
+
+    assert client.flush_calls == 0
+
+
+def test_capture_remains_enabled_and_backward_compatible_by_default(
+    monkeypatch,
+) -> None:
+    class FakePosthog:
+        def __init__(self):
+            self.captures = []
+
+        def capture(self, event_name, *, distinct_id, properties) -> None:
+            self.captures.append((event_name, distinct_id, properties))
+
+    client = FakePosthog()
+    monkeypatch.setattr(tracker, "_get_posthog", lambda: client)
+    monkeypatch.setattr(tracker, "get_user_id", lambda: "generated-user-id")
+
+    tracker.capture(_package_visit_event())
+    tracker.capture(_package_visit_event(), "provided-user-id")
+
+    assert [capture[0] for capture in client.captures] == [
+        "PackageVisitEvent",
+        "PackageVisitEvent",
+    ]
+    assert [capture[1] for capture in client.captures] == [
+        "generated-user-id",
+        "provided-user-id",
+    ]
+    assert all(capture[2]["run_id"] == tracker.RUN_ID for capture in client.captures)
+    assert all(
+        capture[2]["package_name"] == "com.example.settings"
+        for capture in client.captures
+    )
+
+
+def test_posthog_client_is_constructed_once_under_concurrency(monkeypatch) -> None:
+    workers = 16
+    start_barrier = threading.Barrier(workers)
+    constructed = []
+
+    class FakePosthog:
+        def __init__(self, **kwargs):
+            # Release the GIL long enough for an unlocked lazy initializer to race.
+            time.sleep(0.02)
+            self.kwargs = kwargs
+            constructed.append(self)
+
+    monkeypatch.setattr(tracker, "Posthog", FakePosthog)
+
+    def get_client():
+        start_barrier.wait(timeout=5)
+        return tracker._get_posthog()
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        clients = list(executor.map(lambda _: get_client(), range(workers)))
+
+    assert len(constructed) == 1
+    assert all(client is constructed[0] for client in clients)
+    assert constructed[0].kwargs == {
+        "project_api_key": tracker.PROJECT_API_KEY,
+        "host": tracker.HOST,
+        "disable_geoip": False,
+    }
+
+
+def test_package_event_forwards_state_telemetry_setting(monkeypatch) -> None:
+    from mobilerun.agent.droid import state as state_module
+
+    captured = []
+
+    def fake_capture(event, user_id=None, *, config_enabled=True) -> None:
+        captured.append((event, user_id, config_enabled))
+
+    monkeypatch.setattr(state_module, "capture", fake_capture)
+    state = state_module.MobileAgentState(
+        user_id="state-user",
+        step_number=7,
+        telemetry_config_enabled=False,
+    )
+
+    state.update_current_app("com.android.settings", ".Settings")
+
+    assert len(captured) == 1
+    event, user_id, config_enabled = captured[0]
+    assert event == PackageVisitEvent(
+        package_name="com.android.settings",
+        activity_name=".Settings",
+        step_number=7,
+    )
+    assert user_id == "state-user"
+    assert config_enabled is False
+
+
+def test_mobile_agent_copies_telemetry_config_to_shared_state(monkeypatch) -> None:
+    from mobilerun.agent.droid import droid_agent as agent_module
+    from mobilerun.config_manager.config_manager import (
+        AgentConfig,
+        MobileConfig,
+        TelemetryConfig,
+    )
+
+    monkeypatch.setattr(agent_module, "setup_tracing", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        agent_module.MobileAgent,
+        "_configure_default_logging",
+        lambda *args, **kwargs: None,
+    )
+    config = MobileConfig(
+        agent=AgentConfig(name="telemetry-test-external-agent"),
+        telemetry=TelemetryConfig(enabled=False),
+    )
+
+    agent = agent_module.MobileAgent("Check telemetry", config=config)
+
+    assert agent.shared_state.telemetry_config_enabled is False
+
+
+def test_mobile_agent_lifecycle_forwards_disabled_telemetry_config(
+    monkeypatch,
+) -> None:
+    from llama_index.core.llms.mock import MockLLM
+    from llama_index.core.workflow import StartEvent
+
+    from mobilerun.agent.droid import droid_agent as agent_module
+    from mobilerun.agent.droid.events import FinalizeEvent
+    from mobilerun.config_manager.config_manager import MobileConfig, TelemetryConfig
+    from mobilerun.telemetry.events import (
+        MobileAgentFinalizeEvent,
+        MobileAgentInitEvent,
+    )
+
+    class FakeDriver:
+        platform = "Android"
+        supported = set()
+        supported_buttons = set()
+
+        async def get_date(self) -> str:
+            return "2026-08-31"
+
+    class FakeStateProvider:
+        requires_coordinate_tools = False
+        supported = set()
+
+    class FakeRegistry:
+        def disable_unsupported(self, capabilities) -> None:
+            return None
+
+        def disable(self, names) -> None:
+            return None
+
+        def register_from_dict(self, tools) -> None:
+            return None
+
+    class FakeContext:
+        def __init__(self):
+            self.events = []
+
+        def write_event_to_stream(self, event) -> None:
+            self.events.append(event)
+
+    captures = []
+    flushes = []
+
+    def fake_capture(event, user_id=None, *, config_enabled=True) -> None:
+        captures.append((event, user_id, config_enabled))
+
+    async def fake_flush(*, config_enabled=True) -> None:
+        flushes.append(config_enabled)
+
+    async def fake_build_tool_registry(**kwargs):
+        return FakeRegistry(), {"tap"}
+
+    monkeypatch.setenv(PRIMARY_TELEMETRY_ENV, "true")
+    monkeypatch.delenv("MOBILERUN_STREAM_SCREENSHOTS", raising=False)
+    monkeypatch.delenv("DROIDRUN_STREAM_SCREENSHOTS", raising=False)
+    monkeypatch.setattr(agent_module, "setup_tracing", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        agent_module.MobileAgent,
+        "_configure_default_logging",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(agent_module, "build_tool_registry", fake_build_tool_registry)
+    monkeypatch.setattr(agent_module, "capture", fake_capture)
+    monkeypatch.setattr(agent_module, "flush", fake_flush)
+
+    agent = agent_module.MobileAgent(
+        "Check telemetry lifecycle",
+        config=MobileConfig(telemetry=TelemetryConfig(enabled=False)),
+        llms=MockLLM(),
+        driver=FakeDriver(),
+        state_provider=FakeStateProvider(),
+        user_id="lifecycle-user",
+    )
+    context = FakeContext()
+
+    async def run_lifecycle() -> None:
+        await agent.start_handler(context, StartEvent())
+        await agent.finalize(
+            context,
+            FinalizeEvent(success=True, reason="Lifecycle complete"),
+        )
+
+    asyncio.run(run_lifecycle())
+
+    assert len(captures) == 2
+    assert isinstance(captures[0][0], MobileAgentInitEvent)
+    assert isinstance(captures[1][0], MobileAgentFinalizeEvent)
+    assert [capture[1] for capture in captures] == [
+        "lifecycle-user",
+        "lifecycle-user",
+    ]
+    assert [capture[2] for capture in captures] == [False, False]
+    assert flushes == [False]
+
+
+def test_print_telemetry_message_respects_config_false(monkeypatch) -> None:
+    messages = []
+    monkeypatch.setenv(PRIMARY_TELEMETRY_ENV, "true")
+    monkeypatch.setattr(tracker.mobilerun_logger, "debug", messages.append)
+
+    tracker.print_telemetry_message(config_enabled=False)
+
+    assert messages == [tracker.TELEMETRY_DISABLED_MESSAGE]
+
+
+def test_cli_run_and_test_forward_loaded_telemetry_config(monkeypatch) -> None:
+    from mobilerun.cli import main as cli_main
+    from mobilerun.config_manager.config_manager import MobileConfig, TelemetryConfig
+
+    class StopAfterTelemetryMessage(Exception):
+        pass
+
+    forwarded = []
+    config = MobileConfig(telemetry=TelemetryConfig(enabled=False))
+
+    def capture_config(*, config_enabled=True) -> None:
+        forwarded.append(config_enabled)
+        raise StopAfterTelemetryMessage
+
+    async def skip_keyboard_cleanup(config) -> None:
+        return None
+
+    monkeypatch.setattr(cli_main.ConfigLoader, "load", lambda _: config)
+    monkeypatch.setattr(cli_main, "_setup_cli_logging", lambda _: None)
+    monkeypatch.setattr(cli_main, "print_telemetry_message", capture_config)
+    monkeypatch.setattr(cli_main, "_cleanup_android_keyboard", skip_keyboard_cleanup)
+    monkeypatch.setattr(cli_main.console, "print", lambda *args, **kwargs: None)
+
+    assert asyncio.run(cli_main.run_command("Check telemetry", debug=False)) is False
+    assert asyncio.run(cli_main.test("Check telemetry", debug=False)) is None
+    assert forwarded == [False, False]

--- a/tests/test_visual_remote_connection.py
+++ b/tests/test_visual_remote_connection.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
+from mobilerun_core_local.driver.ios import IOSDriver
 from PIL import Image
 
 from mobilerun.agent.droid.droid_agent import MobileAgent, _effective_disabled_tools
@@ -12,7 +13,6 @@ from mobilerun.agent.utils.actions import click_area, click_at, long_press_at, s
 from mobilerun.agent.utils.signatures import build_tool_registry
 from mobilerun.config_manager.config_manager import MobileConfig
 from mobilerun.config_manager.prompt_loader import PromptLoader
-from mobilerun_core_local.driver.ios import IOSDriver
 from mobilerun.tools.helpers.images import (
     image_dimensions,
     resize_image_to_max_side,


### PR DESCRIPTION
## Summary

- honor `TelemetryConfig(enabled=False)` across agent initialization, package visits, finalization, flush, and CLI status reporting
- combine configuration and environment policy so either can disable telemetry
- avoid PostHog and user-ID side effects when telemetry is disabled
- make lazy PostHog initialization thread-safe
- document configuration and environment precedence

## Validation

- `PHOENIX_WORKING_DIR=/private/tmp/mobilerun-phoenix .venv/bin/pytest -q tests/test_telemetry.py` — 18 passed
- `PHOENIX_WORKING_DIR=/private/tmp/mobilerun-phoenix .venv/bin/pytest -q` — 621 passed, 3 subtests passed
- Ruff — passed
- Black `--check .` — passed
- Android 16 (`Medium_Phone_API_36.1`, SDK 36) with Portal 0.7.22 installed and enabled — verified
- Gemini-backed MobileAgent run with `MOBILERUN_TELEMETRY_ENABLED=true` and `TelemetryConfig(enabled=False)` — completed in 5 steps and reported Android 16
- E2E telemetry assertions — 0 PostHog clients, captures, flushes, user-ID calls, or telemetry errors

Fixes #426