### PR TITLE
feat: migrate to Langfuse v4 and refresh vulnerable dependencies

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -16,4 +16,4 @@ jobs:
         with:
           options: "--check --diff --verbose"
           src: "."
-          version: "25.9.0"
+          version: "26.5.1"

--- a/docs/features/tracing.mdx
+++ b/docs/features/tracing.mdx
@@ -120,8 +120,12 @@ Langfuse provides LLM observability with features like session tracking, user an
 ```sh
 export LANGFUSE_SECRET_KEY=sk-lf-...
 export LANGFUSE_PUBLIC_KEY=pk-lf-...
-export LANGFUSE_HOST=https://cloud.langfuse.com
+export LANGFUSE_BASE_URL=https://cloud.langfuse.com
 ```
+
+`LANGFUSE_BASE_URL` is the canonical endpoint variable. The legacy
+`LANGFUSE_HOST` variable remains a fallback. An explicit `langfuse_host` value
+in Mobilerun configuration takes precedence over both environment variables.
 
 **Via config.yaml:**
 ```yaml

--- a/docs/sdk/configuration.mdx
+++ b/docs/sdk/configuration.mdx
@@ -172,7 +172,7 @@ TracingConfig(
     # Langfuse settings (only used if provider="langfuse")
     langfuse_secret_key="",             # LANGFUSE_SECRET_KEY env var
     langfuse_public_key="",             # LANGFUSE_PUBLIC_KEY env var
-    langfuse_host="",                   # LANGFUSE_HOST env var (e.g., "https://cloud.langfuse.com")
+    langfuse_host="",                   # Endpoint override; otherwise LANGFUSE_BASE_URL
     langfuse_user_id="anonymous",       # User ID for Langfuse tracing
     langfuse_session_id="",             # Empty = auto-generate UUID; custom value to persist across runs
 )

--- a/mobilerun/agent/utils/tracing_setup.py
+++ b/mobilerun/agent/utils/tracing_setup.py
@@ -8,6 +8,7 @@ This module provides a centralized way to configure tracing providers
 import base64
 import logging
 import os
+import threading
 from typing import Optional
 from uuid import uuid4
 
@@ -22,6 +23,13 @@ _session_id: str = _default_session_id
 _tracing_initialized: bool = False
 _tracing_provider: Optional[str] = None
 _user_id: str = "anonymous"
+_langfuse_client: Optional[object] = None
+_langfuse_preprocessor: Optional[object] = None
+_langfuse_tracer_provider: Optional[object] = None
+_langfuse_setup_attempted: bool = False
+_tracing_setup_lock = threading.Lock()
+
+DEFAULT_LANGFUSE_BASE_URL = "https://us.cloud.langfuse.com"
 
 
 def setup_tracing(
@@ -34,40 +42,34 @@ def setup_tracing(
 
     provider = tracing_config.provider.lower()
 
-    if tracing_config.langfuse_session_id:
-        _session_id = tracing_config.langfuse_session_id
-    else:
-        _session_id = _default_session_id
+    with _tracing_setup_lock:
+        _session_id = tracing_config.langfuse_session_id or _default_session_id
+        _user_id = tracing_config.langfuse_user_id or "anonymous"
 
-    if tracing_config.langfuse_user_id:
-        _user_id = tracing_config.langfuse_user_id
-    else:
-        _user_id = "anonymous"
+        if _tracing_initialized:
+            logger.debug(
+                f"🔍 Tracing already initialized with {_tracing_provider}, skipping setup"
+            )
+            if provider == "langfuse" and agent:
+                from mobilerun.telemetry.langfuse_processor import set_current_agent
 
-    if _tracing_initialized:
-        logger.debug(
-            f"🔍 Tracing already initialized with {_tracing_provider}, skipping setup"
-        )
-        if provider == "langfuse" and agent:
-            from mobilerun.telemetry.langfuse_processor import set_current_agent
+                set_current_agent(agent)
+            return
 
-            set_current_agent(agent)
-        return
-
-    if provider == "phoenix":
-        if _setup_phoenix_tracing():
-            _tracing_initialized = True
-            _tracing_provider = "phoenix"
-    elif provider == "langfuse":
-        _setup_langfuse_tracing(tracing_config, agent)
-        _tracing_initialized = True
-        _tracing_provider = "langfuse"
-        logger.debug(f"🔍 Langfuse tracing enabled | Session: {_session_id}")
-    else:
-        logger.warning(
-            f"⚠️  Unknown tracing provider: {provider}. "
-            f"Supported providers: phoenix, langfuse"
-        )
+        if provider == "phoenix":
+            if _setup_phoenix_tracing():
+                _tracing_initialized = True
+                _tracing_provider = "phoenix"
+        elif provider == "langfuse":
+            if _setup_langfuse_tracing(tracing_config, agent):
+                _tracing_initialized = True
+                _tracing_provider = "langfuse"
+                logger.debug(f"🔍 Langfuse tracing enabled | Session: {_session_id}")
+        else:
+            logger.warning(
+                f"⚠️  Unknown tracing provider: {provider}. "
+                f"Supported providers: phoenix, langfuse"
+            )
 
 
 def _check_phoenix_reachable(endpoint: str, timeout: float = 3.0) -> bool:
@@ -112,43 +114,44 @@ def _setup_phoenix_tracing() -> bool:
 
 def _setup_langfuse_tracing(
     tracing_config: TracingConfig, agent: Optional[object] = None
-) -> None:
+) -> bool:
     """
-    Set up Langfuse tracing with custom span processor.
+    Set up Langfuse tracing with a preprocessor and the public v4 client.
 
     Args:
         tracing_config: TracingConfig instance containing Langfuse credentials
         agent: Optional MobileAgent instance to pass to span processor
     """
 
-    try:
-        # Set environment variables
-        if tracing_config.langfuse_secret_key:
-            os.environ["LANGFUSE_SECRET_KEY"] = tracing_config.langfuse_secret_key
-        if tracing_config.langfuse_public_key:
-            os.environ["LANGFUSE_PUBLIC_KEY"] = tracing_config.langfuse_public_key
-        if tracing_config.langfuse_host:
-            os.environ["LANGFUSE_HOST"] = tracing_config.langfuse_host
-        else:
-            os.environ["LANGFUSE_HOST"] = "https://us.cloud.langfuse.com"
+    global _langfuse_client
+    global _langfuse_preprocessor, _langfuse_tracer_provider
+    global _langfuse_setup_attempted
 
-        # Verify credentials
+    try:
         from langfuse import Langfuse
 
-        langfuse = Langfuse()
-        try:
-            if not langfuse.auth_check():
-                logger.error(
-                    "❌ Langfuse authentication failed. Please check your credentials."
-                )
-                return
-        except Exception as e:
-            logger.error(
-                f"Error checking Langfuse authentication: {e}\nLikely a network issue or credentials are incorrect"
-            )
-            return
+        public_key = tracing_config.langfuse_public_key or os.getenv(
+            "LANGFUSE_PUBLIC_KEY"
+        )
+        secret_key = tracing_config.langfuse_secret_key or os.getenv(
+            "LANGFUSE_SECRET_KEY"
+        )
+        base_url = _resolve_langfuse_base_url(tracing_config)
 
-        # STEP 1: Set up tracer provider (before any LlamaIndex imports!)
+        if not public_key or not secret_key:
+            logger.error(
+                "❌ Langfuse credentials are missing. Configure both the public and secret key."
+            )
+            return False
+
+        if _langfuse_setup_attempted:
+            logger.error(
+                "Langfuse tracing initialization already failed in this process; "
+                "restart before retrying."
+            )
+            return False
+
+        # STEP 1: Set up the tracer provider.
         from opentelemetry import trace
         from opentelemetry.sdk.trace import TracerProvider
 
@@ -164,7 +167,14 @@ def _setup_langfuse_tracing(
             trace.set_tracer_provider(tracer_provider)
             logger.debug("🔍 Created new TracerProvider")
 
-        # STEP 2: Instrument LlamaIndex FIRST (before any LlamaIndex imports!)
+        if _provider_has_langfuse_processor(tracer_provider):
+            logger.error(
+                "Langfuse tracing is already registered on the active tracer provider; "
+                "Mobilerun cannot guarantee preprocessing or export policy."
+            )
+            return False
+
+        # STEP 2: Instrument LlamaIndex.
         from openinference.instrumentation.llama_index import LlamaIndexInstrumentor
 
         instrumentor = LlamaIndexInstrumentor()
@@ -174,21 +184,23 @@ def _setup_langfuse_tracing(
         else:
             logger.debug("🔍 LlamaIndex already instrumented")
 
-        # STEP 3: Patch the encoder (now that instrumentation is active)
+        # STEP 3: Patch the encoder once (now that instrumentation is active).
         from openinference.instrumentation.llama_index import _handler
         from pydantic import BaseModel as PydanticV2BaseModel
 
-        _original_encoder = _handler._encoder
+        if not getattr(_handler._encoder, "_mobilerun_pydantic_v2", False):
+            original_encoder = _handler._encoder
 
-        def _fixed_encoder(obj):
-            """Fixed encoder that properly handles Pydantic v2 models."""
-            if isinstance(obj, PydanticV2BaseModel):
-                return obj.model_dump()
-            return _original_encoder(obj)
+            def _fixed_encoder(obj):
+                """Encode Pydantic v2 models for OpenInference."""
+                if isinstance(obj, PydanticV2BaseModel):
+                    return obj.model_dump()
+                return original_encoder(obj)
 
-        _handler._encoder = _fixed_encoder
+            _fixed_encoder._mobilerun_pydantic_v2 = True
+            _handler._encoder = _fixed_encoder
 
-        # STEP 4: Add our custom processor (after instrumentation is set up)
+        # STEP 4: Register preprocessing before Langfuse registers its exporter.
         from mobilerun.telemetry.langfuse_processor import (
             LangfuseSpanProcessor,
             set_current_agent,
@@ -197,12 +209,53 @@ def _setup_langfuse_tracing(
         if agent:
             set_current_agent(agent)
 
-        span_processor = LangfuseSpanProcessor(
-            public_key=os.environ["LANGFUSE_PUBLIC_KEY"],
-            secret_key=os.environ["LANGFUSE_SECRET_KEY"],
-            base_url=os.environ["LANGFUSE_HOST"],
+        if (
+            _langfuse_preprocessor is None
+            or _langfuse_tracer_provider is not tracer_provider
+        ):
+            _langfuse_preprocessor = LangfuseSpanProcessor()
+            tracer_provider.add_span_processor(_langfuse_preprocessor)
+            _langfuse_tracer_provider = tracer_provider
+
+        # STEP 5: The public client owns the single exporter, queue, media uploads,
+        # flushing, and shutdown. Export all spans so Mobilerun's custom workflow
+        # and screenshot spans are not removed by Langfuse v4's default filter.
+        # A failed SDK construction can leave processors attached to an OTel
+        # provider, whose public API cannot remove them. Do not retry in-process:
+        # that is the only general way to guarantee no duplicate exporters.
+        _langfuse_setup_attempted = True
+        client = Langfuse(
+            public_key=public_key,
+            secret_key=secret_key,
+            base_url=base_url,
+            tracer_provider=tracer_provider,
+            should_export_span=_export_all_spans,
         )
-        tracer_provider.add_span_processor(span_processor)
+
+        if not _provider_has_owned_langfuse_pipeline(tracer_provider):
+            logger.error(
+                "Langfuse is already initialized on another tracer provider; "
+                "Mobilerun cannot guarantee preprocessing or export policy."
+            )
+            return False
+
+        _langfuse_client = client
+
+        try:
+            if not _langfuse_client.auth_check():
+                logger.error(
+                    "❌ Langfuse authentication failed. Please check your credentials."
+                )
+        except Exception as error:
+            logger.error(
+                "Unable to verify Langfuse authentication; tracing remains configured."
+            )
+            logger.debug(
+                "Langfuse authentication diagnostic failed (%s)",
+                type(error).__name__,
+            )
+
+        return True
 
     except ImportError as e:
         logger.warning(
@@ -212,6 +265,58 @@ def _setup_langfuse_tracing(
             "    • If installed via pip: `uv pip install mobilerun[langfuse]`\n"
             f"    Missing: {e.name if hasattr(e, 'name') else str(e)}\n"
         )
+        return False
+    except Exception as error:
+        logger.error("Failed to initialize Langfuse tracing (%s)", type(error).__name__)
+        return False
+
+
+def _resolve_langfuse_base_url(tracing_config: TracingConfig) -> str:
+    """Resolve the Langfuse endpoint, keeping LANGFUSE_HOST as a fallback."""
+    return (
+        tracing_config.langfuse_host
+        or os.getenv("LANGFUSE_BASE_URL")
+        or os.getenv("LANGFUSE_HOST")
+        or DEFAULT_LANGFUSE_BASE_URL
+    )
+
+
+def _export_all_spans(_span) -> bool:
+    """Keep custom Mobilerun spans alongside standard LLM spans in Langfuse."""
+    return True
+
+
+def _provider_has_langfuse_processor(tracer_provider: object) -> bool:
+    """Detect an exporter installed before Mobilerun's required preprocessor."""
+    return any(
+        type(processor).__module__.startswith("langfuse.")
+        for processor in _provider_span_processors(tracer_provider)
+    )
+
+
+def _provider_has_owned_langfuse_pipeline(tracer_provider: object) -> bool:
+    """Confirm exactly one SDK exporter follows Mobilerun's preprocessor."""
+    processors = _provider_span_processors(tracer_provider)
+    try:
+        preprocessor_index = processors.index(_langfuse_preprocessor)
+    except ValueError:
+        return False
+
+    exporter_indexes = [
+        index
+        for index, processor in enumerate(processors)
+        if type(processor).__module__.startswith("langfuse.")
+    ]
+    return len(exporter_indexes) == 1 and preprocessor_index < exporter_indexes[0]
+
+
+def _provider_span_processors(tracer_provider: object) -> tuple[object, ...]:
+    """Read the active OTel pipeline for ordering validation."""
+    active_processor = getattr(tracer_provider, "_active_span_processor", None)
+    processors = getattr(active_processor, "_span_processors", None)
+    if processors is None:
+        processors = getattr(tracer_provider, "processors", ())
+    return tuple(processors)
 
 
 def apply_session_context() -> None:

--- a/mobilerun/agent/utils/tracing_setup.py
+++ b/mobilerun/agent/utils/tracing_setup.py
@@ -140,7 +140,7 @@ def _setup_langfuse_tracing(
 
         if not public_key or not secret_key:
             logger.error(
-                "❌ Langfuse credentials are missing. Configure both the public and secret key."
+                "Langfuse credentials are missing. Configure both the public and secret key."
             )
             return False
 
@@ -244,7 +244,7 @@ def _setup_langfuse_tracing(
         try:
             if not _langfuse_client.auth_check():
                 logger.error(
-                    "❌ Langfuse authentication failed. Please check your credentials."
+                    "Langfuse authentication failed. Please check your credentials."
                 )
         except Exception as error:
             logger.error(

--- a/mobilerun/config_example.yaml
+++ b/mobilerun/config_example.yaml
@@ -159,10 +159,10 @@ tracing:
   provider: phoenix
   # Upload screenshots to Langfuse (cloud traces)
   langfuse_screenshots: false
-  # Langfuse configuration (set as environment variables if not empty string)
-  langfuse_secret_key: ""  # LANGFUSE_SECRET_KEY
-  langfuse_public_key: ""  # LANGFUSE_PUBLIC_KEY
-  langfuse_host: ""        # LANGFUSE_HOST
+  # Langfuse configuration (explicit values override environment variables)
+  langfuse_secret_key: ""  # Explicit key override; otherwise LANGFUSE_SECRET_KEY
+  langfuse_public_key: ""  # Explicit key override; otherwise LANGFUSE_PUBLIC_KEY
+  langfuse_host: ""        # Explicit endpoint; otherwise LANGFUSE_BASE_URL
   langfuse_user_id: "anonymous"  # User ID for tracing
   langfuse_session_id: ""  # Session ID (empty = auto-generate UUID per process)
 

--- a/mobilerun/config_manager/config_manager.py
+++ b/mobilerun/config_manager/config_manager.py
@@ -196,9 +196,9 @@ class TracingConfig:
     enabled: bool = False
     provider: str = "phoenix"  # "phoenix" or "langfuse"
     langfuse_screenshots: bool = False  # Upload screenshots to Langfuse (if enabled)
-    langfuse_secret_key: str = ""  # Set as LANGFUSE_SECRET_KEY env var if not empty
-    langfuse_public_key: str = ""  # Set as LANGFUSE_PUBLIC_KEY env var if not empty
-    langfuse_host: str = ""  # Set as LANGFUSE_HOST env var if not empty
+    langfuse_secret_key: str = ""  # Explicit key override
+    langfuse_public_key: str = ""  # Explicit key override
+    langfuse_host: str = ""  # Explicit endpoint override
     langfuse_user_id: str = "anonymous"
     langfuse_session_id: str = (
         ""  # Empty = auto-generate UUID; set to custom value to persist across runs

--- a/mobilerun/telemetry/langfuse_processor.py
+++ b/mobilerun/telemetry/langfuse_processor.py
@@ -1,40 +1,19 @@
-"""Production-ready Langfuse span processor with image upload support.
+"""OpenTelemetry span preprocessing for the Langfuse integration.
 
-This module provides a custom OpenTelemetry span processor that:
-- Uploads images to Langfuse blob storage (S3/Azure/GCS)
-- Transforms LlamaIndex block-based messages to Langfuse content format
-- Auto-scales from 3 to 50 worker threads based on load
-- Uses HTTP connection pooling for performance
-- Operates silently (warnings and errors only)
-
-Usage:
-    from mobilerun.telemetry.langfuse_processor import LangfuseSpanProcessor
-
-    processor = LangfuseSpanProcessor(
-        public_key="pk-lf-...",
-        secret_key="sk-lf-...",
-        base_url="https://cloud.langfuse.com",
-    )
+Langfuse owns span export, batching, and media upload. This processor runs
+before the Langfuse processor and only normalizes Mobilerun/OpenInference spans
+into the attributes understood by Langfuse.
 """
 
 import base64
-import hashlib
 import json
 import logging
-import threading
-import time
-from concurrent.futures import Future, ThreadPoolExecutor
 from contextvars import ContextVar
-from datetime import datetime, timezone
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
-import requests
-from langfuse._client.span_processor import (
-    LangfuseSpanProcessor as BaseLangfuseSpanProcessor,
-)
 from opentelemetry import trace
 from opentelemetry.context import Context
-from opentelemetry.sdk.trace import ReadableSpan, Span
+from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
 
 from mobilerun import __version__
 
@@ -47,10 +26,13 @@ _current_agent: ContextVar[Optional["MobileAgent"]] = ContextVar(
 _root_span_context: ContextVar[Optional[Context]] = ContextVar(
     "_root_span_context", default=None
 )
-# Track last active step span (FastAgent/Manager/Executor) to parent screenshots
 _last_step_span_context: ContextVar[Optional[Context]] = ContextVar(
     "_last_step_span_context", default=None
 )
+
+MAX_IMAGE_SIZE_KB = 10000
+
+logger = logging.getLogger("mobilerun")
 
 
 def set_current_agent(agent: "MobileAgent") -> None:
@@ -58,10 +40,9 @@ def set_current_agent(agent: "MobileAgent") -> None:
 
 
 def set_root_span_context(span: Span) -> None:
-    """Store the root span context so screenshots can attach even if current span is missing."""
+    """Store the root span context for screenshots created outside an active span."""
     try:
-        ctx = trace.set_span_in_context(span)
-        _root_span_context.set(ctx)
+        _root_span_context.set(trace.set_span_in_context(span))
     except Exception:
         pass
 
@@ -72,8 +53,7 @@ def get_root_span_context() -> Optional[Context]:
 
 def set_last_step_span_context(span: Span) -> None:
     try:
-        ctx = trace.set_span_in_context(span)
-        _last_step_span_context.set(ctx)
+        _last_step_span_context.set(trace.set_span_in_context(span))
     except Exception:
         pass
 
@@ -82,362 +62,123 @@ def get_last_step_span_context() -> Optional[Context]:
     return _last_step_span_context.get()
 
 
-MAX_IMAGE_SIZE_KB = 10000
-MAX_UPLOAD_WORKERS = 50  # Maximum concurrent upload threads
-SHUTDOWN_TIMEOUT = 30  # Seconds to wait for pending uploads on shutdown
+class LangfuseSpanProcessor(SpanProcessor):
+    """Normalize spans before Langfuse's public OTel exporter sees them.
 
-# Use Mobilerun's logger
-logger = logging.getLogger("mobilerun")
-
-
-class LangfuseSpanProcessor(BaseLangfuseSpanProcessor):
-    """
-    Production span processor with image upload and message formatting.
-
-    Extends the base LangfuseSpanProcessor with:
-    - Auto-scaling thread pool (3-50 workers based on load)
-    - Image upload to blob storage with deduplication
-    - Message format transformation (blocks → content)
+    This processor deliberately does not export, batch, upload, or own threads.
+    Register it before constructing the public :class:`langfuse.Langfuse`
+    client so the client's processor receives the normalized span.
     """
 
-    def __init__(
-        self,
-        *,
-        public_key: str,
-        secret_key: str,
-        base_url: str,
-        timeout: Optional[int] = None,
-        flush_at: Optional[int] = None,
-        flush_interval: Optional[float] = None,
-        blocked_instrumentation_scopes: Optional[List[str]] = None,
-        additional_headers: Optional[dict] = None,
-        agent: Optional["MobileAgent"] = None,
-    ):
-        """Initialize the span processor with media upload support.
-
-        Args:
-            agent: Optional MobileAgent instance for accessing agent context during span processing.
-        """
-        super().__init__(
-            public_key=public_key,
-            secret_key=secret_key,
-            base_url=base_url,
-            timeout=timeout,
-            flush_at=flush_at,
-            flush_interval=flush_interval,
-            blocked_instrumentation_scopes=blocked_instrumentation_scopes,
-            additional_headers=additional_headers,
-        )
-
-        # Store credentials for media API calls
-        self._base_url = base_url
-        auth_string = f"{public_key}:{secret_key}"
-        self._auth_header = "Basic " + base64.b64encode(auth_string.encode()).decode()
-
-        # HTTP connection pooling (shared across all threads)
-        self._http_session = requests.Session()
-        self._http_session.headers.update(
-            {
-                "Authorization": self._auth_header,
-                "Content-Type": "application/json",
-            }
-        )
-        adapter = requests.adapters.HTTPAdapter(
-            pool_connections=3,  # Increase this if hosting on server with multiple users
-            pool_maxsize=10,  # Increase this if hosting on server with multiple users (task api)
-            max_retries=3,
-        )
-        self._http_session.mount("http://", adapter)
-        self._http_session.mount("https://", adapter)
-
-        self._executor = ThreadPoolExecutor(
-            max_workers=MAX_UPLOAD_WORKERS,
-            thread_name_prefix="LangfuseMediaUpload",
-        )
-
-        self._pending_uploads: List[Future] = []
-        self._pending_lock = threading.Lock()
+    def __init__(self, agent: Optional["MobileAgent"] = None) -> None:
+        if agent is not None:
+            set_current_agent(agent)
 
     @property
     def agent(self) -> Optional["MobileAgent"]:
         return _current_agent.get()
 
     def _extract_agent_input(self) -> Optional[dict]:
-        if not self.agent:
+        agent = self.agent
+        if not agent:
             return None
 
         try:
-            input_data = {}
+            input_data: dict[str, Any] = {}
 
-            if self.agent.shared_state.instruction:
-                input_data["goal"] = self.agent.shared_state.instruction
+            if agent.shared_state.instruction:
+                input_data["goal"] = agent.shared_state.instruction
 
-            input_data["reasoning"] = self.agent.config.agent.reasoning
+            input_data["reasoning"] = agent.config.agent.reasoning
 
-            if self.agent.config.device:
-                device = self.agent.config.device
+            if agent.config.device:
+                device = agent.config.device
                 input_data["device"] = {
                     "platform": device.platform,
                     "serial": device.serial,
                     "use_tcp": device.use_tcp,
                 }
 
-            if self.agent.output_model:
-                input_data["output_model"] = self.agent.output_model.__name__
+            if agent.output_model:
+                input_data["output_model"] = agent.output_model.__name__
 
             input_data["droidrun_version"] = "v" + __version__
 
-            if self.agent.config.agent.after_sleep_action:
-                input_data["after_action_sleep"] = (
-                    self.agent.config.agent.after_sleep_action
-                )
+            if agent.config.agent.after_sleep_action:
+                input_data["after_action_sleep"] = agent.config.agent.after_sleep_action
 
-            # Vision settings
             vision_state = {
-                "manager": getattr(self.agent.config.agent.manager, "vision", False),
-                "executor": getattr(self.agent.config.agent.executor, "vision", False),
-                "fast_agent": getattr(
-                    self.agent.config.agent.fast_agent, "vision", False
-                ),
+                "manager": getattr(agent.config.agent.manager, "vision", False),
+                "executor": getattr(agent.config.agent.executor, "vision", False),
+                "fast_agent": getattr(agent.config.agent.fast_agent, "vision", False),
             }
             input_data["vision_enabled"] = any(vision_state.values())
             input_data["vision"] = vision_state
 
-            active_llms = []
-            if self.agent.config.agent.reasoning:
-                # Reasoning mode uses manager, executor
-                llm_attrs = ["manager_llm", "executor_llm"]
-            else:
-                # Direct mode uses fast_agent
-                llm_attrs = ["fast_agent_llm"]
-
-            # Add helper LLMs
+            llm_attrs = (
+                ["manager_llm", "executor_llm"]
+                if agent.config.agent.reasoning
+                else ["fast_agent_llm"]
+            )
             llm_attrs.append("app_opener_llm")
-
-            # Add structured_output if output_model is present
-            if self.agent.output_model:
+            if agent.output_model:
                 llm_attrs.append("structured_output_llm")
 
+            active_llms = []
             for llm_attr in llm_attrs:
-                llm = getattr(self.agent, llm_attr)
-                if llm:
-                    role = llm_attr.replace("_llm", "")
-                    llm_info = {
-                        "role": role,
-                        "provider": (
-                            llm.class_name()
-                            if hasattr(llm, "class_name")
-                            else "unknown"
-                        ),
-                    }
-                    if role in vision_state:
-                        llm_info["vision"] = vision_state[role]
+                llm = getattr(agent, llm_attr, None)
+                if llm is None:
+                    continue
 
-                    # Extract model name
-                    if hasattr(llm, "model"):
-                        llm_info["model"] = llm.model
-                    elif hasattr(llm, "metadata") and hasattr(
-                        llm.metadata, "model_name"
-                    ):
-                        llm_info["model"] = llm.metadata.model_name
+                role = llm_attr.replace("_llm", "")
+                llm_info = {
+                    "role": role,
+                    "provider": (
+                        llm.class_name() if hasattr(llm, "class_name") else "unknown"
+                    ),
+                }
+                if role in vision_state:
+                    llm_info["vision"] = vision_state[role]
 
-                    # Extract temperature
-                    if hasattr(llm, "temperature"):
-                        llm_info["temperature"] = llm.temperature
+                if hasattr(llm, "model"):
+                    llm_info["model"] = llm.model
+                elif hasattr(llm, "metadata") and hasattr(llm.metadata, "model_name"):
+                    llm_info["model"] = llm.metadata.model_name
 
-                    active_llms.append(llm_info)
+                if hasattr(llm, "temperature"):
+                    llm_info["temperature"] = llm.temperature
+
+                active_llms.append(llm_info)
 
             input_data["llms"] = active_llms
-
             return input_data
-
-        except Exception as e:
-            logger.warning(f"Failed to extract agent input: {e}")
-            return None
-
-    # Media API
-    def _submit_upload(self, job: dict):
-        """Submit upload job to thread pool (non-blocking)."""
-        try:
-            future = self._executor.submit(self._upload_media_to_langfuse, job)
-
-            with self._pending_lock:
-                self._pending_uploads.append(future)
-
-            future.add_done_callback(self._cleanup_future)
-
-        except Exception as e:
-            logger.error(f"Failed to submit media upload: {e}")
-
-    def _cleanup_future(self, future: Future):
-        """Remove completed future from tracking list."""
-        with self._pending_lock:
-            try:
-                self._pending_uploads.remove(future)
-            except ValueError:
-                pass
-
-    def _upload_media_to_langfuse(self, job: dict):
-        """Upload media to Langfuse blob storage."""
-        try:
-            # Step 1: Request presigned upload URL
-            upload_response = self._request_upload_url(
-                media_id=job["media_id"],
-                content_type=job["content_type"],
-                content_length=job["content_length"],
-                sha256_hash=job["sha256_hash"],
-                trace_id=job["trace_id"],
-                observation_id=job.get("observation_id"),
-                field=job["field"],
-            )
-
-            if not upload_response or not upload_response.get("uploadUrl"):
-                # Media already exists (deduplication)
-                return
-
-            upload_url = upload_response["uploadUrl"]
-
-            # Step 2: Upload to blob storage (S3/Azure/GCS)
-            headers = {"Content-Type": job["content_type"]}
-
-            # GCS doesn't support these headers
-            if "storage.googleapis.com" not in upload_url:
-                headers["x-ms-blob-type"] = "BlockBlob"
-                headers["x-amz-checksum-sha256"] = job["sha256_hash"]
-
-            response = self._http_session.put(
-                upload_url, headers=headers, data=job["content_bytes"]
-            )
-
-            # Step 3: Notify Langfuse of upload completion
-            if response.status_code in (200, 201):
-                self._notify_upload_complete(job["media_id"], response.status_code)
-            else:
-                logger.error(
-                    f"Media upload failed for {job['media_id']}: "
-                    f"HTTP {response.status_code} - {response.text}"
-                )
-
-        except Exception as e:
-            logger.error(f"Failed to upload media {job['media_id']}: {e}")
-
-    def _request_upload_url(
-        self,
-        media_id: str,
-        content_type: str,
-        content_length: int,
-        sha256_hash: str,
-        trace_id: str,
-        observation_id: Optional[str],
-        field: str,
-    ) -> Optional[dict]:
-        """Request presigned upload URL from Langfuse API."""
-        try:
-            url = f"{self._base_url}/api/public/media"
-            payload = {
-                "traceId": trace_id,
-                "observationId": observation_id,
-                "contentType": content_type,
-                "contentLength": content_length,
-                "sha256Hash": sha256_hash,
-                "field": field,
-            }
-
-            response = self._http_session.post(url, json=payload, timeout=10)
-
-            if response.status_code == 200:
-                return response.json()
-            elif response.status_code == 201:
-                data = response.json()
-                if data.get("uploadUrl") is None:
-                    # media already exists (deduplication)
-                    return None
-                return data
-            else:
-                logger.error(
-                    f"Failed to request upload URL: HTTP {response.status_code} - {response.text}"
-                )
-                return None
-
-        except Exception as e:
-            logger.error(f"Error requesting upload URL: {e}")
-            return None
-
-    def _notify_upload_complete(self, media_id: str, status_code: int):
-        """Notify Langfuse that upload completed."""
-        try:
-            url = f"{self._base_url}/api/public/media/{media_id}"
-            payload = {
-                "uploadedAt": datetime.now(timezone.utc).isoformat(),
-                "uploadHttpStatus": status_code,
-            }
-
-            response = self._http_session.patch(url, json=payload, timeout=10)
-
-            if response.status_code != 200:
-                logger.warning(
-                    f"Failed to notify upload complete: HTTP {response.status_code}"
-                )
-
-        except Exception as e:
-            logger.error(f"Error notifying upload complete: {e}")
-
-    def shutdown(self):
-        """Override shutdown to wait for pending media uploads."""
-
-        self._executor.shutdown(wait=False, cancel_futures=False)
-
-        # Wait for pending uploads with timeout
-        deadline = time.time() + SHUTDOWN_TIMEOUT
-        all_done = False
-
-        while time.time() < deadline:
-            with self._pending_lock:
-                pending = [f for f in self._pending_uploads if not f.done()]
-                pending_count = len(pending)
-
-            if pending_count == 0:
-                all_done = True
-                break
-
-            time.sleep(0.1)
-
-        if not all_done:
-            with self._pending_lock:
-                pending_count = len([f for f in self._pending_uploads if not f.done()])
+        except Exception as error:
             logger.warning(
-                f"Langfuse shutdown timeout after {SHUTDOWN_TIMEOUT}s - "
-                f"{pending_count} media uploads still pending"
+                "Failed to extract Langfuse agent metadata (%s)",
+                type(error).__name__,
             )
-
-        self._http_session.close()
-
-        super().shutdown()
+            return None
 
     def on_start(self, span: Span, parent_context: Optional[Context] = None) -> None:
-        super().on_start(span, parent_context)
+        del parent_context
 
-        if not self.agent:
+        attrs = getattr(span, "_attributes", None)
+        if attrs is None or not self.agent:
             return
 
         try:
-            if "input.value" in span._attributes:
-                del span._attributes["input.value"]
+            attrs.pop("input.value", None)
 
             if span.name == "MobileAgent.run":
                 set_root_span_context(span)
-                span._attributes["langfuse.release"] = "v" + __version__
+                attrs["langfuse.release"] = "v" + __version__
                 input_data = self._extract_agent_input()
                 if input_data:
-                    span._attributes["langfuse.observation.input"] = json.dumps(
-                        input_data
+                    attrs["langfuse.observation.input"] = json.dumps(input_data)
+                    attrs["langfuse.trace.tags"] = (
+                        ["reasoning"] if input_data.get("reasoning") else ["fast"]
                     )
-                    tags = ["reasoning"] if input_data.get("reasoning") else ["fast"]
-                    span._attributes["langfuse.trace.tags"] = tags
-                    if "vision_enabled" in input_data:
-                        span._attributes["droidrun.vision.enabled"] = input_data[
-                            "vision_enabled"
-                        ]
+                    attrs["droidrun.vision.enabled"] = input_data["vision_enabled"]
 
             elif span.name in (
                 "ManagerAgent.run",
@@ -446,50 +187,36 @@ class LangfuseSpanProcessor(BaseLangfuseSpanProcessor):
                 "ExecutorAgent.run",
             ):
                 set_last_step_span_context(span)
-                memory_size = (
-                    len(self.agent.shared_state.agent_memory)
-                    if self.agent.shared_state.agent_memory
-                    else 0
-                )
-                message_history_count = len(self.agent.shared_state.message_history) + 1
-
+                agent = self.agent
+                memory = agent.shared_state.agent_memory
                 input_data = {
-                    "memory_size": memory_size,
-                    "message_history_count": message_history_count,
+                    "memory_size": len(memory) if memory else 0,
+                    "message_history_count": len(agent.shared_state.message_history)
+                    + 1,
                 }
 
                 if span.name == "ExecutorAgent.run":
                     input_data["subgoal"] = (
-                        self.agent.shared_state.current_subgoal or "Unknown"
+                        agent.shared_state.current_subgoal or "Unknown"
                     )
 
-                span._attributes["langfuse.observation.input"] = json.dumps(input_data)
+                attrs["langfuse.observation.input"] = json.dumps(input_data)
+                if agent.shared_state.error_flag_plan:
+                    attrs["langfuse.trace.tags"] = ["error_recovery"]
+        except Exception as error:
+            logger.warning(
+                "Failed to add Langfuse span metadata (%s)", type(error).__name__
+            )
 
-                if self.agent.shared_state.error_flag_plan:
-                    span._attributes["langfuse.trace.tags"] = ["error_recovery"]
-
-        except Exception as e:
-            logger.error(f"Error injecting metadata in on_start: {e}")
-
-    # Span processing
     def on_end(self, span: ReadableSpan) -> None:
-        if self._is_langfuse_span(span) and not self._is_langfuse_project_span(span):
+        attrs = getattr(span, "_attributes", None)
+        if attrs is None:
             return
-
-        if self._is_blocked_instrumentation_scope(span):
-            return
-
-        if span.name.endswith("_done"):
-            span._attributes["langfuse.observation.level"] = "DEBUG"
 
         try:
-            if "output.value" in span._attributes and not span._attributes.get(
-                "langfuse.observation.output"
-            ):
-                span._attributes["langfuse.observation.output"] = span._attributes[
-                    "output.value"
-                ]
-                del span._attributes["output.value"]
+            if span.name.endswith("_done"):
+                attrs["langfuse.observation.level"] = "DEBUG"
+
             if span.name in (
                 "MobileAgent.run",
                 "ManagerAgent.run",
@@ -497,8 +224,7 @@ class LangfuseSpanProcessor(BaseLangfuseSpanProcessor):
                 "ExecutorAgent.run",
                 "FastAgent.run",
             ):
-                if "input.value" in span._attributes:
-                    del span._attributes["input.value"]
+                attrs.pop("input.value", None)
             elif span.name.endswith(
                 (".chat", ".achat", ".stream_chat", ".astream_chat")
             ):
@@ -509,126 +235,123 @@ class LangfuseSpanProcessor(BaseLangfuseSpanProcessor):
                 self._format_complete(span)
             elif span.name == "droidrun.screenshot":
                 self._process_screenshot_span(span)
-        except Exception as e:
-            logger.error(f"Error processing span for Langfuse: {e}")
 
-        super(BaseLangfuseSpanProcessor, self).on_end(span)
+            output = attrs.pop("output.value", None)
+            if output is not None and not attrs.get("langfuse.observation.output"):
+                attrs["langfuse.observation.output"] = output
+        except Exception as error:
+            logger.warning(
+                "Failed to preprocess a span for Langfuse (%s)",
+                type(error).__name__,
+            )
+
+    def shutdown(self) -> None:
+        """No-op: the public Langfuse client owns exporter shutdown."""
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        """The processor has no queue; all preprocessing is synchronous."""
+        del timeout_millis
+        return True
 
     def _format_complete(self, span: ReadableSpan) -> None:
-        span._attributes["input.value"] = span._attributes["llm.prompts"][0]
-        del span._attributes["llm.prompts"]
-        pass
+        attrs = getattr(span, "_attributes", None)
+        if attrs is None:
+            return
+
+        prompts = attrs.pop("llm.prompts", None)
+        if isinstance(prompts, (list, tuple)) and prompts:
+            attrs["input.value"] = prompts[0]
+        self._process_field(attrs, "input")
+        self._process_field(attrs, "output")
 
     def _format_chat(self, span: ReadableSpan) -> None:
-        """
-        Apply custom formatting to transform blocks and set Langfuse attributes.
-
-        Processes both input.value and output.value attributes:
-        - Plain strings: Set langfuse.observation.{field} directly
-        - JSON with blocks: Transform blocks to content format (images, tool calls, etc.)
-        - JSON without blocks: Set langfuse.observation.{field} as-is
-        """
-        if not hasattr(span, "_attributes") or span._attributes is None:
+        attrs = getattr(span, "_attributes", None)
+        if attrs is None:
             return
 
-        attrs = span._attributes
-        trace_id = format(span.context.trace_id, "032x")
+        self._process_field(attrs, "input")
+        self._process_field(attrs, "output")
 
-        self._process_field(attrs, trace_id, "input")
-        self._process_field(attrs, trace_id, "output")
-
-    # Message transformation
-    def _process_field(self, attrs: dict, trace_id: str, field: str) -> None:
-        """Process input or output field - handle both JSON messages and plain strings."""
+    def _process_field(self, attrs: dict, field: str) -> None:
+        """Normalize an OpenInference input/output value for Langfuse."""
         field_key = f"{field}.value"
-
-        if field_key not in attrs:
-            return
-
-        value = attrs[field_key]
+        value = attrs.get(field_key)
         if not isinstance(value, str):
             return
 
-        # Try parsing as JSON with messages
         try:
             data = json.loads(value)
-
-            # Check if it has messages with blocks that need transformation
             if self._has_blocks_to_transform(data):
-                self._transform_and_set_field(attrs, trace_id, field, data)
+                self._transform_and_set_field(attrs, field, data)
                 return
-
+            sanitized, contains_data_uri = self._sanitize_serialized_data_uris(data)
+            if contains_data_uri:
+                attrs[f"langfuse.observation.{field}"] = json.dumps(sanitized)
+                attrs.pop(field_key, None)
+                return
         except (json.JSONDecodeError, ValueError):
             pass
 
         attrs[f"langfuse.observation.{field}"] = value
+        attrs.pop(field_key, None)
 
-    def _has_blocks_to_transform(self, data: dict) -> bool:
-        """Check if data contains messages with blocks that need transformation."""
-        if not isinstance(data, dict) or "messages" not in data:
+    @staticmethod
+    def _has_blocks_to_transform(data: object) -> bool:
+        if not isinstance(data, dict) or not isinstance(data.get("messages"), list):
             return False
 
-        messages = data["messages"]
-        if not isinstance(messages, list):
-            return False
+        return any(
+            isinstance(message, dict)
+            and (
+                "blocks" in message
+                or (
+                    isinstance(message.get("json"), dict)
+                    and "blocks" in message["json"]
+                )
+            )
+            for message in data["messages"]
+        )
 
-        return any(isinstance(msg, dict) and "blocks" in msg for msg in messages)
-
-    def _transform_and_set_field(
-        self, attrs: dict, trace_id: str, field: str, data: dict
-    ) -> None:
-        """Transform blocks to content and set Langfuse attributes."""
-        # Remove legacy LLM message attributes
+    def _transform_and_set_field(self, attrs: dict, field: str, data: dict) -> None:
         prefix = f"llm.{field}_messages."
-        keys_to_remove = [key for key in attrs if key.startswith(prefix)]
-        for key in keys_to_remove:
+        for key in [key for key in attrs if key.startswith(prefix)]:
             del attrs[key]
 
-        # Transform and set
-        formatted = self._transform_blocks_to_content(data, trace_id, field)
+        formatted = self._transform_blocks_to_content(data)
         attrs[f"langfuse.observation.{field}"] = formatted
-        attrs[f"{field}.value"] = formatted
+        attrs.pop(f"{field}.value", None)
 
-    def _transform_blocks_to_content(
-        self, data: dict, trace_id: str, field: str
-    ) -> str:
-        """Transform parsed message data from blocks to content format."""
-        processed = self._convert_message_array(data["messages"], trace_id, field)
-        return json.dumps({"messages": json.loads(processed)})
+    def _transform_blocks_to_content(self, data: dict) -> str:
+        processed = self._convert_message_array(data["messages"])
+        return json.dumps({"messages": processed})
 
-    def _convert_message_array(self, messages: list, trace_id: str, field: str) -> str:
-        """Convert message array from blocks format to content format."""
+    def _convert_message_array(self, messages: list) -> list:
         restructured_messages = []
 
-        for msg in messages:
-            if not isinstance(msg, dict):
+        for original_message in messages:
+            if not isinstance(original_message, dict):
                 continue
 
-            if "content" in msg and "blocks" not in msg:
-                restructured_messages.append(msg)
+            message = original_message
+            if "content" in message and "blocks" not in message:
+                restructured_messages.append(message)
                 continue
 
-            if (
-                "json" in msg
-                and isinstance(msg["json"], dict)
-                and "blocks" in msg["json"]
-            ):
-                msg = msg.copy()
-                msg.update(msg["json"])
-                del msg["json"]
+            if isinstance(message.get("json"), dict) and "blocks" in message["json"]:
+                message = message.copy()
+                message.update(message.pop("json"))
 
-            if "blocks" not in msg or "role" not in msg:
-                if "role" in msg:
-                    restructured_messages.append(msg)
+            if "blocks" not in message or "role" not in message:
+                if "role" in message:
+                    restructured_messages.append(message)
                 continue
 
-            role = msg["role"]
-            blocks = msg["blocks"]
-
-            if not isinstance(blocks, list) or len(blocks) == 0:
-                restructured_messages.append(msg)
+            blocks = message["blocks"]
+            if not isinstance(blocks, list) or not blocks:
+                restructured_messages.append(message)
                 continue
 
+            role = message["role"]
             if (
                 len(blocks) == 1
                 and isinstance(blocks[0], dict)
@@ -638,158 +361,170 @@ class LangfuseSpanProcessor(BaseLangfuseSpanProcessor):
                 restructured_messages.append(
                     {"role": role, "content": blocks[0]["text"]}
                 )
+                continue
+
+            content_blocks = self._convert_blocks_to_content(blocks)
+            if content_blocks:
+                restructured_messages.append({"role": role, "content": content_blocks})
+            elif any(
+                isinstance(block, dict) and block.get("block_type") == "image"
+                for block in blocks
+            ):
+                # Never restore rejected image bytes into exported attributes.
+                restructured_messages.append({"role": role, "content": []})
             else:
-                content_blocks = self._convert_blocks_to_content(
-                    blocks, trace_id, field
-                )
+                restructured_messages.append(message)
 
-                if content_blocks:
-                    restructured_messages.append(
-                        {"role": role, "content": content_blocks}
-                    )
-                else:
-                    restructured_messages.append(msg)
+        return restructured_messages
 
-        return json.dumps(restructured_messages)
-
-    def _convert_blocks_to_content(
-        self,
-        blocks: list,
-        trace_id: str,
-        field: str,
-    ) -> list:
-        """Convert LlamaIndex blocks to Langfuse content blocks."""
+    def _convert_blocks_to_content(self, blocks: list) -> list:
         content_blocks = []
 
         for block in blocks:
-            if not isinstance(block, dict) or "block_type" not in block:
+            if not isinstance(block, dict):
                 continue
 
-            block_type = block["block_type"]
-
-            if block_type == "text":
-                if "text" in block:
-                    content_blocks.append({"type": "text", "text": block["text"]})
-
+            block_type = block.get("block_type")
+            if block_type == "text" and "text" in block:
+                content_blocks.append({"type": "text", "text": block["text"]})
             elif block_type == "image":
-                image_block = self._upload_image_to_storage(block, trace_id, field)
+                image_block = self._prepare_image_for_native_upload(block)
                 if image_block:
                     content_blocks.append(image_block)
-
-            elif block_type == "tool_call":
-                if "tool_name" in block and "tool_kwargs" in block:
-                    content_blocks.append(
-                        {
-                            "type": "tool_call",
-                            "tool_call": {
-                                "name": block["tool_name"],
-                                "arguments": block["tool_kwargs"],
-                            },
-                        }
-                    )
+            elif (
+                block_type == "tool_call"
+                and "tool_name" in block
+                and "tool_kwargs" in block
+            ):
+                content_blocks.append(
+                    {
+                        "type": "tool_call",
+                        "tool_call": {
+                            "name": block["tool_name"],
+                            "arguments": block["tool_kwargs"],
+                        },
+                    }
+                )
 
         return content_blocks
 
-    def _process_screenshot_span(self, span: ReadableSpan) -> None:
-        """Convert custom screenshot spans into Langfuse image content."""
-        attrs = span._attributes or {}
-        image_b64 = attrs.get("droidrun.screenshot.image_base64")
-        mime_type = attrs.get("droidrun.screenshot.mime_type", "image/png")
+    @classmethod
+    def _sanitize_serialized_data_uris(cls, value: Any) -> tuple[Any, bool]:
+        """Apply the image limit to media already serialized as content."""
+        if isinstance(value, str) and value.startswith("data:"):
+            prepared = cls._prepare_image_for_native_upload(
+                {"image": value, "image_mimetype": "application/octet-stream"}
+            )
+            return (value if prepared else ""), True
 
-        if not image_b64:
+        if isinstance(value, list):
+            sanitized_items = []
+            contains_data_uri = False
+            for item in value:
+                sanitized, found = cls._sanitize_serialized_data_uris(item)
+                sanitized_items.append(sanitized)
+                contains_data_uri = contains_data_uri or found
+            return sanitized_items, contains_data_uri
+
+        if isinstance(value, dict):
+            sanitized_mapping = {}
+            contains_data_uri = False
+            for key, item in value.items():
+                sanitized, found = cls._sanitize_serialized_data_uris(item)
+                sanitized_mapping[key] = sanitized
+                contains_data_uri = contains_data_uri or found
+            return sanitized_mapping, contains_data_uri
+
+        return value, False
+
+    def _process_screenshot_span(self, span: ReadableSpan) -> None:
+        attrs = getattr(span, "_attributes", None)
+        if attrs is None:
             return
 
-        trace_id = format(span.context.trace_id, "032x")
-        data = {
-            "messages": [
+        image = attrs.get("droidrun.screenshot.image_base64")
+        mime_type = attrs.get("droidrun.screenshot.mime_type", "image/png")
+        if not image:
+            return
+
+        image_content = self._prepare_image_for_native_upload(
+            {
+                "image": image,
+                "image_mimetype": mime_type,
+            }
+        )
+        if image_content:
+            attrs["langfuse.observation.output"] = json.dumps(
                 {
-                    "role": "assistant",
-                    "blocks": [
+                    "messages": [
                         {
-                            "block_type": "image",
-                            "image": image_b64,
-                            "image_mimetype": mime_type,
+                            "role": "assistant",
+                            "content": [image_content],
                         }
-                    ],
+                    ]
                 }
-            ]
-        }
+            )
 
-        attrs["output.value"] = json.dumps(data)
-        self._transform_and_set_field(attrs, trace_id, "output", data)
-
-        # Clean up raw fields to avoid duplication
         attrs.pop("droidrun.screenshot.image_base64", None)
         attrs.pop("droidrun.screenshot.mime_type", None)
         attrs.pop("output.value", None)
 
-    # Image upload
-    def _upload_image_to_storage(
-        self,
-        block: dict,
-        trace_id: str,
-        field: str,
-    ) -> Optional[dict]:
-        """Upload image to blob storage and return media reference."""
-        if "image" in block and block["image"] is not None:
-            image_base64 = block["image"]
+    @staticmethod
+    def _prepare_image_for_native_upload(block: dict) -> Optional[dict]:
+        """Return media in a form Langfuse v4 uploads during span export."""
+        image = block.get("image")
+        if image is not None:
             mime_type = block.get("image_mimetype")
+            if not isinstance(image, str):
+                logger.warning("Image data is invalid; skipping upload")
+                return None
 
-            if not mime_type:
-                logger.warning("Image missing MIME type, skipping upload")
+            encoded = image
+            if image.startswith("data:") and "," in image:
+                header, encoded = image.split(",", 1)
+                if header.endswith(";base64"):
+                    mime_type = header[5:-7]
+                else:
+                    logger.warning(
+                        "Image data URI is not base64 encoded; skipping upload"
+                    )
+                    return None
+            elif not isinstance(mime_type, str):
+                logger.warning("Image MIME type is invalid; skipping upload")
                 return None
 
             try:
-                image_bytes = base64.b64decode(image_base64)
-                size_kb = len(image_bytes) / 1024
-
-                if size_kb > MAX_IMAGE_SIZE_KB:
-                    logger.warning(
-                        f"Image size ({size_kb:.1f}KB) exceeds limit ({MAX_IMAGE_SIZE_KB}KB), skipping upload"
-                    )
-                    return None
-
-                sha256_hash_bytes = hashlib.sha256(image_bytes).digest()
-                sha256_hash = base64.b64encode(sha256_hash_bytes).decode()
-                media_id = (
-                    sha256_hash.replace("+", "-").replace("/", "_").rstrip("=")[:22]
-                )
-
-                self._submit_upload(
-                    {
-                        "media_id": media_id,
-                        "content_bytes": image_bytes,
-                        "content_type": mime_type,
-                        "content_length": len(image_bytes),
-                        "sha256_hash": sha256_hash,
-                        "trace_id": trace_id,
-                        "observation_id": None,
-                        "field": field,
-                    }
-                )
-
-                reference_string = (
-                    f"@@@langfuseMedia:type={mime_type}|id={media_id}|source=bytes@@@"
-                )
-                return {
-                    "type": "image_url",
-                    "image_url": {"url": reference_string},
-                }
-
-            except Exception as e:
-                logger.error(f"Failed to process image: {e}")
+                image_bytes = base64.b64decode(encoded, validate=True)
+            except (ValueError, TypeError):
+                logger.warning("Image data is not valid base64; skipping upload")
                 return None
 
-        if "url" in block and block["url"] is not None:
-            return {"type": "image_url", "image_url": {"url": block["url"]}}
+            size_kb = len(image_bytes) / 1024
+            if size_kb > MAX_IMAGE_SIZE_KB:
+                logger.warning(
+                    "Image size (%.1fKB) exceeds limit (%dKB); skipping upload",
+                    size_kb,
+                    MAX_IMAGE_SIZE_KB,
+                )
+                return None
 
-        if "path" in block and block["path"] is not None:
-            logger.warning(
-                f"Using file path for image - may not work on server: {block['path']}"
-            )
-            return {
-                "type": "image_url",
-                "image_url": {"url": f"file://{block['path']}"},
-            }
+            data_uri = f"data:{mime_type};base64,{encoded}"
+            return {"type": "image_url", "image_url": {"url": data_uri}}
+
+        url = block.get("url")
+        if isinstance(url, str):
+            if url.startswith("data:"):
+                return LangfuseSpanProcessor._prepare_image_for_native_upload(
+                    {
+                        "image": url,
+                        "image_mimetype": "application/octet-stream",
+                    }
+                )
+            return {"type": "image_url", "image_url": {"url": url}}
+
+        path = block.get("path")
+        if isinstance(path, str):
+            logger.warning("Using a local image path; it may not resolve in Langfuse")
+            return {"type": "image_url", "image_url": {"url": f"file://{path}"}}
 
         return None

--- a/mobilerun/telemetry/langfuse_processor.py
+++ b/mobilerun/telemetry/langfuse_processor.py
@@ -410,8 +410,17 @@ class LangfuseSpanProcessor(SpanProcessor):
 
     @classmethod
     def _sanitize_serialized_data_uris(cls, value: Any) -> tuple[Any, bool]:
-        """Apply the image limit to media already serialized as content."""
-        if isinstance(value, str) and value.startswith("data:"):
+        """Apply media limits to base64 data URIs already serialized as content."""
+        if isinstance(value, str):
+            header, separator, _payload = value.partition(",")
+            is_base64_data_uri = (
+                value.startswith("data:")
+                and bool(separator)
+                and header.endswith(";base64")
+            )
+            if not is_base64_data_uri:
+                return value, False
+
             prepared = cls._prepare_image_for_native_upload(
                 {"image": value, "image_mimetype": "application/octet-stream"}
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,14 +10,14 @@ dependencies = [
     "pydantic>=2.11.10",
     "rich>=14.1.0",
     "InquirerPy>=0.3.4",
-    "arize-phoenix>=12.3.0",
+    "arize-phoenix>=14.4.0",
     "httpx>=0.27.0",
     "filelock>=3.20.0",
-    "PyJWT[crypto]>=2.10.0",
+    "PyJWT[crypto]>=2.13.0",
     "llama-index-callbacks-arize-phoenix>=0.6.1",
     "llama-index-workflows>=2.16.0,<3.0.0",
     "aiofiles>=25.1.0",
-    "mcp>=1.26.0",
+    "mcp>=1.28.1,<2.0.0",
     "llama-index-llms-openai==0.7.10",
     "llama-index-llms-openai-like==0.7.2",
     "llama-index-llms-google-genai>=0.8.5",
@@ -60,7 +60,7 @@ anthropic = [
     "llama-index-llms-anthropic>=0.8.6,<0.9.0",
 ]
 dev = [
-    "black==25.9.0",
+    "black==26.5.1",
     "ruff>=0.13.0",
     "mypy>=1.0.0",
     "pytest>=8.0.0",
@@ -175,7 +175,7 @@ contents = ["mobilerun.tools.cloud.MobileRunTools.*"]
 
 [dependency-groups]
 dev = [
-    "arize-phoenix>=11.32.1",
+    "arize-phoenix>=14.4.0",
     "anthropic>=0.67.0",
     "bandit>=1.8.6",
     "llama-index-callbacks-arize-phoenix>=0.6.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dev = [
     "mobilerun[langfuse]",
 ]
 langfuse = [
-    "langfuse==3.12.1",
+    "langfuse==4.15.1",
     "openinference-instrumentation-llama-index>=3.0.0",
     "llama-index-instrumentation"
 ]

--- a/tests/test_langfuse_v4.py
+++ b/tests/test_langfuse_v4.py
@@ -1,0 +1,446 @@
+import base64
+import json
+import time
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import (
+    SimpleSpanProcessor,
+    SpanExporter,
+    SpanExportResult,
+)
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+
+from mobilerun.agent.utils import tracing_setup
+from mobilerun.config_manager.config_manager import TracingConfig
+from mobilerun.telemetry import langfuse_processor
+from mobilerun.telemetry.langfuse_processor import LangfuseSpanProcessor
+
+
+@pytest.fixture(autouse=True)
+def reset_tracing_state(monkeypatch):
+    monkeypatch.setattr(tracing_setup, "_tracing_initialized", False)
+    monkeypatch.setattr(tracing_setup, "_tracing_provider", None)
+    monkeypatch.setattr(tracing_setup, "_langfuse_client", None)
+    monkeypatch.setattr(tracing_setup, "_langfuse_preprocessor", None)
+    monkeypatch.setattr(tracing_setup, "_langfuse_tracer_provider", None)
+    monkeypatch.setattr(tracing_setup, "_langfuse_setup_attempted", False)
+    monkeypatch.setattr(tracing_setup, "_session_id", "test-session")
+    monkeypatch.setattr(tracing_setup, "_user_id", "anonymous")
+    for name in (
+        "LANGFUSE_PUBLIC_KEY",
+        "LANGFUSE_SECRET_KEY",
+        "LANGFUSE_BASE_URL",
+        "LANGFUSE_HOST",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    agent_token = langfuse_processor._current_agent.set(None)
+    root_token = langfuse_processor._root_span_context.set(None)
+    step_token = langfuse_processor._last_step_span_context.set(None)
+    yield
+    langfuse_processor._current_agent.reset(agent_token)
+    langfuse_processor._root_span_context.reset(root_token)
+    langfuse_processor._last_step_span_context.reset(step_token)
+
+
+class _FakeTracerProvider:
+    def __init__(self):
+        self.processors = []
+
+    def add_span_processor(self, processor):
+        self.processors.append(processor)
+
+
+def _install_fake_setup(
+    monkeypatch, *, auth_result=True, auth_error=None, attach_exporter=True
+):
+    import langfuse
+    from openinference.instrumentation import llama_index as instrumentation
+    from openinference.instrumentation.llama_index import _handler
+
+    provider = _FakeTracerProvider()
+    clients = []
+
+    class FakeExporter:
+        pass
+
+    FakeExporter.__module__ = "langfuse._client.span_processor"
+    exporter = FakeExporter()
+    instrument_calls = []
+
+    class FakeInstrumentor:
+        is_instrumented_by_opentelemetry = False
+
+        def instrument(self):
+            instrument_calls.append(True)
+
+    class FakeLangfuse:
+        def __init__(self, **kwargs):
+            time.sleep(0.01)
+            self.kwargs = kwargs
+            clients.append(self)
+            if attach_exporter:
+                kwargs["tracer_provider"].add_span_processor(exporter)
+
+        def auth_check(self):
+            if auth_error:
+                raise auth_error
+            return auth_result
+
+    monkeypatch.setattr(trace, "get_tracer_provider", lambda: provider)
+    monkeypatch.setattr(instrumentation, "LlamaIndexInstrumentor", FakeInstrumentor)
+    monkeypatch.setattr(_handler, "_encoder", lambda obj: obj)
+    monkeypatch.setattr(langfuse, "Langfuse", FakeLangfuse)
+    return provider, clients, exporter, instrument_calls
+
+
+def _langfuse_config(**kwargs):
+    values = {
+        "enabled": True,
+        "provider": "langfuse",
+        "langfuse_public_key": "pk-test",
+        "langfuse_secret_key": "sk-test",
+    }
+    values.update(kwargs)
+    return TracingConfig(**values)
+
+
+def test_setup_is_concurrent_safe_and_registers_preprocessor_first(monkeypatch):
+    provider, clients, exporter, instrument_calls = _install_fake_setup(monkeypatch)
+    config = _langfuse_config()
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(lambda _: tracing_setup.setup_tracing(config), range(16)))
+
+    assert len(clients) == 1
+    assert instrument_calls == [True]
+    assert isinstance(provider.processors[0], LangfuseSpanProcessor)
+    assert provider.processors[1:] == [exporter]
+    assert clients[0].kwargs["should_export_span"](object()) is True
+    assert tracing_setup._tracing_initialized is True
+    assert tracing_setup._tracing_provider == "langfuse"
+
+
+@pytest.mark.parametrize(
+    ("auth_result", "auth_error"),
+    [(False, None), (True, RuntimeError("sensitive-detail"))],
+)
+def test_auth_diagnostic_does_not_retry_or_leak_details(
+    monkeypatch, caplog, auth_result, auth_error
+):
+    _provider, clients, _exporter, _calls = _install_fake_setup(
+        monkeypatch, auth_result=auth_result, auth_error=auth_error
+    )
+
+    tracing_setup.setup_tracing(_langfuse_config())
+    tracing_setup.setup_tracing(_langfuse_config())
+
+    assert len(clients) == 1
+    assert tracing_setup._tracing_initialized is True
+    assert "sensitive-detail" not in caplog.text
+
+
+def test_failed_client_construction_cannot_accumulate_processors(monkeypatch):
+    import langfuse
+    from openinference.instrumentation import llama_index as instrumentation
+    from openinference.instrumentation.llama_index import _handler
+
+    provider = _FakeTracerProvider()
+    construction_count = 0
+
+    class FakeInstrumentor:
+        is_instrumented_by_opentelemetry = True
+
+    class FailingLangfuse:
+        def __init__(self, **_kwargs):
+            nonlocal construction_count
+            construction_count += 1
+            raise ValueError("sensitive-detail")
+
+    monkeypatch.setattr(trace, "get_tracer_provider", lambda: provider)
+    monkeypatch.setattr(instrumentation, "LlamaIndexInstrumentor", FakeInstrumentor)
+    monkeypatch.setattr(_handler, "_encoder", lambda obj: obj)
+    monkeypatch.setattr(langfuse, "Langfuse", FailingLangfuse)
+
+    tracing_setup.setup_tracing(_langfuse_config())
+    tracing_setup.setup_tracing(_langfuse_config())
+
+    assert construction_count == 1
+    assert len(provider.processors) == 1
+    assert isinstance(provider.processors[0], LangfuseSpanProcessor)
+    assert tracing_setup._tracing_initialized is False
+
+
+def test_setup_rejects_preexisting_langfuse_exporter(monkeypatch, caplog):
+    provider, clients, _exporter, _calls = _install_fake_setup(monkeypatch)
+
+    class ExistingLangfuseExporter:
+        pass
+
+    ExistingLangfuseExporter.__module__ = "langfuse._client.span_processor"
+    provider._active_span_processor = SimpleNamespace(
+        _span_processors=(ExistingLangfuseExporter(),)
+    )
+
+    tracing_setup.setup_tracing(_langfuse_config())
+
+    assert clients == []
+    assert provider.processors == []
+    assert tracing_setup._tracing_initialized is False
+    assert "pk-test" not in caplog.text
+    assert "sk-test" not in caplog.text
+
+
+def test_setup_rejects_same_key_client_owned_by_another_provider(monkeypatch, caplog):
+    provider, clients, _exporter, _calls = _install_fake_setup(
+        monkeypatch, attach_exporter=False
+    )
+
+    tracing_setup.setup_tracing(_langfuse_config())
+
+    assert len(clients) == 1
+    assert len(provider.processors) == 1
+    assert isinstance(provider.processors[0], LangfuseSpanProcessor)
+    assert tracing_setup._langfuse_client is None
+    assert tracing_setup._tracing_initialized is False
+    assert "pk-test" not in caplog.text
+    assert "sk-test" not in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("explicit", "base_env", "legacy_env", "expected"),
+    [
+        ("https://explicit", "https://base", "https://legacy", "https://explicit"),
+        ("", "https://base", "https://legacy", "https://base"),
+        ("", "", "https://legacy", "https://legacy"),
+        ("", "", "", tracing_setup.DEFAULT_LANGFUSE_BASE_URL),
+    ],
+)
+def test_langfuse_base_url_precedence(
+    monkeypatch, explicit, base_env, legacy_env, expected
+):
+    if base_env:
+        monkeypatch.setenv("LANGFUSE_BASE_URL", base_env)
+    if legacy_env:
+        monkeypatch.setenv("LANGFUSE_HOST", legacy_env)
+
+    config = _langfuse_config(langfuse_host=explicit)
+    assert tracing_setup._resolve_langfuse_base_url(config) == expected
+
+
+def test_processor_normalizes_agent_and_llm_metadata():
+    class LLM:
+        model = "test-model"
+        temperature = 0.2
+
+        @staticmethod
+        def class_name():
+            return "TestLLM"
+
+    agent = SimpleNamespace(
+        shared_state=SimpleNamespace(
+            instruction="Open Settings",
+            agent_memory=["memory"],
+            message_history=[],
+            current_subgoal=None,
+            error_flag_plan=False,
+        ),
+        config=SimpleNamespace(
+            agent=SimpleNamespace(
+                reasoning=False,
+                after_sleep_action=1,
+                manager=SimpleNamespace(vision=False),
+                executor=SimpleNamespace(vision=False),
+                fast_agent=SimpleNamespace(vision=True),
+            ),
+            device=SimpleNamespace(
+                platform="android", serial="emulator", use_tcp=False
+            ),
+        ),
+        output_model=None,
+        fast_agent_llm=LLM(),
+        app_opener_llm=None,
+    )
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(LangfuseSpanProcessor(agent))
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    with provider.get_tracer("test").start_as_current_span("MobileAgent.run"):
+        pass
+
+    attrs = exporter.get_finished_spans()[0].attributes
+    metadata = json.loads(attrs["langfuse.observation.input"])
+    assert metadata["goal"] == "Open Settings"
+    assert metadata["vision_enabled"] is True
+    assert metadata["llms"][0] == {
+        "role": "fast_agent",
+        "provider": "TestLLM",
+        "vision": True,
+        "model": "test-model",
+        "temperature": 0.2,
+    }
+    assert attrs["langfuse.trace.tags"] == ("fast",)
+
+
+class _CollectingExporter(SpanExporter):
+    def __init__(self):
+        self.spans = []
+
+    def export(self, spans):
+        self.spans.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self):
+        pass
+
+
+def test_public_v4_client_exports_custom_span_once_and_uploads_native_media(
+    monkeypatch,
+):
+    from langfuse import Langfuse
+    from langfuse._task_manager.media_manager import MediaManager
+
+    media_jobs = []
+
+    def record_media(_self, **kwargs):
+        media_jobs.append(kwargs)
+
+    monkeypatch.setattr(MediaManager, "_process_media", record_media)
+    provider = TracerProvider()
+    exporter = _CollectingExporter()
+    preprocessor = LangfuseSpanProcessor()
+    provider.add_span_processor(preprocessor)
+    client = Langfuse(
+        public_key=f"pk-test-{uuid4()}",
+        secret_key="sk-test",
+        base_url="http://127.0.0.1:1",
+        tracer_provider=provider,
+        span_exporter=exporter,
+        should_export_span=lambda _span: True,
+    )
+
+    try:
+        image = base64.b64encode(b"png-bytes").decode()
+        with provider.get_tracer("mobilerun.custom").start_as_current_span(
+            "droidrun.screenshot"
+        ) as span:
+            span.set_attribute("droidrun.screenshot.image_base64", image)
+            span.set_attribute("droidrun.screenshot.mime_type", "image/png")
+        client.flush()
+
+        assert len(exporter.spans) == 1
+        attrs = exporter.spans[0].attributes
+        assert "droidrun.screenshot.image_base64" not in attrs
+        assert "@@@langfuseMedia:type=image/png" in attrs["langfuse.observation.output"]
+        assert len(media_jobs) == 1
+        assert preprocessor.force_flush() is True
+    finally:
+        client.shutdown()
+
+
+def test_native_image_size_and_error_handling(monkeypatch, caplog):
+    monkeypatch.setattr(langfuse_processor, "MAX_IMAGE_SIZE_KB", 0)
+    encoded = base64.b64encode(b"x").decode()
+
+    assert (
+        LangfuseSpanProcessor._prepare_image_for_native_upload(
+            {"image": encoded, "image_mimetype": "image/png"}
+        )
+        is None
+    )
+    assert (
+        LangfuseSpanProcessor._prepare_image_for_native_upload(
+            {"image": "not-base64", "image_mimetype": "image/png"}
+        )
+        is None
+    )
+    assert (
+        LangfuseSpanProcessor._prepare_image_for_native_upload(
+            {"url": f"data:image/png;base64,{encoded}"}
+        )
+        is None
+    )
+    assert "not-base64" not in caplog.text
+
+
+@pytest.mark.parametrize("nested", [False, True])
+def test_rejected_image_bytes_are_not_restored_to_observation_attributes(
+    monkeypatch, nested
+):
+    monkeypatch.setattr(langfuse_processor, "MAX_IMAGE_SIZE_KB", 0)
+    encoded = base64.b64encode(b"oversized-image").decode()
+    message = {
+        "role": "user",
+        "blocks": [
+            {
+                "block_type": "image",
+                "image": encoded,
+                "image_mimetype": "image/png",
+            }
+        ],
+    }
+    if nested:
+        message = {"json": message}
+    attrs = {"input.value": json.dumps({"messages": [message]})}
+
+    LangfuseSpanProcessor()._process_field(attrs, "input")
+
+    assert encoded not in attrs["langfuse.observation.input"]
+    assert "input.value" not in attrs
+
+
+def test_rejected_serialized_content_media_is_removed(monkeypatch):
+    monkeypatch.setattr(langfuse_processor, "MAX_IMAGE_SIZE_KB", 0)
+    encoded = base64.b64encode(b"oversized-image").decode()
+    attrs = {
+        "input.value": json.dumps(
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "image_url",
+                                "image_url": {
+                                    "url": f"data:image/png;base64,{encoded}"
+                                },
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+    }
+
+    LangfuseSpanProcessor()._process_field(attrs, "input")
+
+    assert encoded not in attrs["langfuse.observation.input"]
+    assert "input.value" not in attrs
+
+
+def test_apply_session_context_sets_langfuse_trace_attributes():
+    from openinference.semconv.trace import SpanAttributes
+    from opentelemetry.context import get_value
+
+    tracing_setup._tracing_initialized = True
+    tracing_setup._tracing_provider = "langfuse"
+    tracing_setup._session_id = "session-123"
+    tracing_setup._user_id = "user-123"
+
+    def read_context():
+        tracing_setup.apply_session_context()
+        return (
+            get_value(SpanAttributes.SESSION_ID),
+            get_value(SpanAttributes.USER_ID),
+        )
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        assert pool.submit(read_context).result() == ("session-123", "user-123")

--- a/tests/test_langfuse_v4.py
+++ b/tests/test_langfuse_v4.py
@@ -426,6 +426,62 @@ def test_rejected_serialized_content_media_is_removed(monkeypatch):
     assert "input.value" not in attrs
 
 
+@pytest.mark.parametrize(
+    "value",
+    [
+        "data: ordinary non-media text",
+        {"message": "data: nested non-media text"},
+        ["data: list-contained non-media text"],
+        {"uri": "data:text/plain,hello"},
+    ],
+)
+def test_non_media_data_prefixed_serialized_content_is_preserved(value, caplog):
+    serialized = json.dumps(value)
+    attrs = {"input.value": serialized}
+
+    LangfuseSpanProcessor()._process_field(attrs, "input")
+
+    assert attrs["langfuse.observation.input"] == serialized
+    assert "input.value" not in attrs
+    assert "skipping upload" not in caplog.text
+
+
+def test_mixed_serialized_content_preserves_text_and_removes_oversized_media(
+    monkeypatch,
+):
+    monkeypatch.setattr(langfuse_processor, "MAX_IMAGE_SIZE_KB", 0)
+    encoded = base64.b64encode(b"oversized-image").decode()
+    attrs = {
+        "input.value": json.dumps(
+            {
+                "content": [
+                    "data: ordinary non-media text",
+                    f"data:image/png;base64,{encoded}",
+                ]
+            }
+        )
+    }
+
+    LangfuseSpanProcessor()._process_field(attrs, "input")
+
+    observed = json.loads(attrs["langfuse.observation.input"])
+    assert observed["content"] == ["data: ordinary non-media text", ""]
+    assert encoded not in attrs["langfuse.observation.input"]
+    assert "input.value" not in attrs
+
+
+def test_malformed_base64_serialized_media_is_removed(caplog):
+    attrs = {
+        "input.value": json.dumps({"url": "data:image/png;base64,not-valid-base64"})
+    }
+
+    LangfuseSpanProcessor()._process_field(attrs, "input")
+
+    assert json.loads(attrs["langfuse.observation.input"])["url"] == ""
+    assert "not-valid-base64" not in caplog.text
+    assert "input.value" not in attrs
+
+
 def test_apply_session_context_sets_langfuse_trace_attributes():
     from openinference.semconv.trace import SpanAttributes
     from opentelemetry.context import get_value

--- a/tests/test_mcp_stdio_compatibility.py
+++ b/tests/test_mcp_stdio_compatibility.py
@@ -1,0 +1,103 @@
+import asyncio
+import os
+import sys
+import time
+
+from mobilerun.mcp.adapter import mcp_to_mobilerun_tools
+from mobilerun.mcp.client import MCPClientManager
+from mobilerun.mcp.config import MCPConfig, MCPServerConfig
+
+
+def _process_exists(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+def test_real_stdio_server_discovery_filtering_invocation_and_cleanup(tmp_path):
+    server_script = tmp_path / "compatibility_server.py"
+    server_script.write_text("""
+import os
+
+from mcp.server.fastmcp import FastMCP
+from mcp.types import TextContent
+
+server = FastMCP("mobilerun-compatibility-test")
+
+
+@server.tool()
+def describe(value: str) -> list[TextContent]:
+    return [
+        TextContent(type="text", text=f"value={value}"),
+        TextContent(type="text", text=f"transport={os.environ['MCP_TEST_TRANSPORT']}"),
+        TextContent(type="text", text=f"pid={os.getpid()}"),
+    ]
+
+
+@server.tool()
+def excluded() -> str:
+    return "excluded"
+
+
+@server.tool()
+def not_included() -> str:
+    return "not included"
+
+
+if __name__ == "__main__":
+    server.run(transport="stdio")
+""".lstrip())
+
+    manager = MCPClientManager(
+        MCPConfig(
+            enabled=True,
+            servers={
+                "fixture": MCPServerConfig(
+                    command=sys.executable,
+                    args=[str(server_script)],
+                    env={"MCP_TEST_TRANSPORT": "stdio"},
+                    prefix="compat_",
+                    include_tools=["describe", "excluded"],
+                    exclude_tools=["excluded"],
+                )
+            },
+        )
+    )
+
+    async def exercise_manager() -> tuple[str, int]:
+        pid = 0
+        try:
+            discovered = await manager.discover_tools()
+
+            assert list(discovered) == ["compat_describe"]
+            assert manager.connected_servers == []
+            assert discovered["compat_describe"].original_name == "describe"
+            assert discovered["compat_describe"].input_schema["required"] == ["value"]
+
+            tools = mcp_to_mobilerun_tools(manager)
+            assert list(tools) == ["compat_describe"]
+            assert tools["compat_describe"]["parameters"]["value"] == {
+                "type": "string",
+                "required": True,
+            }
+
+            result = await tools["compat_describe"]["function"](value="hello")
+            lines = result.splitlines()
+            assert lines[:2] == ["value=hello", "transport=stdio"]
+            pid = int(lines[2].removeprefix("pid="))
+            assert manager.connected_servers == ["fixture"]
+            assert _process_exists(pid)
+            return result, pid
+        finally:
+            await manager.disconnect_all()
+            assert manager.connected_servers == []
+
+    result, server_pid = asyncio.run(exercise_manager())
+
+    assert result.startswith("value=hello\ntransport=stdio\npid=")
+    deadline = time.monotonic() + 2
+    while _process_exists(server_pid) and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert not _process_exists(server_pid)

--- a/tests/test_phoenix_tracing.py
+++ b/tests/test_phoenix_tracing.py
@@ -1,0 +1,98 @@
+from types import SimpleNamespace
+
+import llama_index.core
+from openinference.semconv.resource import ResourceAttributes
+
+from mobilerun.agent.utils import tracing_setup
+from mobilerun.telemetry import phoenix
+
+
+def test_callback_factory_configures_otlp_export_and_instrumentor(
+    monkeypatch,
+):
+    calls = SimpleNamespace()
+
+    class FakeExporter:
+        def __init__(self, endpoint):
+            calls.exporter_endpoint = endpoint
+
+    class FakeSpanProcessor:
+        def __init__(self, exporter):
+            calls.exporter = exporter
+
+    class FakeTracerProvider:
+        def __init__(self, resource):
+            calls.resource = resource
+            calls.created_provider = self
+
+        def add_span_processor(self, processor):
+            calls.processor = processor
+
+    class FakeInstrumentor:
+        def instrument(self, **kwargs):
+            calls.instrument_kwargs = kwargs
+            return "phoenix-handler"
+
+    from openinference.instrumentation import llama_index as llama_index_instrumentation
+    from opentelemetry.exporter.otlp.proto.http import trace_exporter
+    from opentelemetry.sdk import trace as trace_sdk
+    from opentelemetry.sdk.trace import export as trace_export
+
+    monkeypatch.setattr(trace_exporter, "OTLPSpanExporter", FakeExporter)
+    monkeypatch.setattr(trace_export, "SimpleSpanProcessor", FakeSpanProcessor)
+    monkeypatch.setattr(trace_sdk, "TracerProvider", FakeTracerProvider)
+    monkeypatch.setattr(
+        llama_index_instrumentation, "LlamaIndexInstrumentor", FakeInstrumentor
+    )
+    monkeypatch.setenv("phoenix_project_name", "compatibility-tests")
+
+    supplied_provider = object()
+    result = phoenix.arize_phoenix_callback_handler(
+        endpoint="http://phoenix.example:6006",
+        tracer_provider=supplied_provider,
+        separate_trace_from_runtime_context=True,
+    )
+
+    assert result == "phoenix-handler"
+    assert calls.exporter_endpoint == "http://phoenix.example:6006/v1/traces"
+    assert calls.exporter is not None
+    assert calls.processor is not None
+    assert (
+        calls.resource.attributes[ResourceAttributes.PROJECT_NAME]
+        == "compatibility-tests"
+    )
+    assert calls.instrument_kwargs["tracer_provider"] is supplied_provider
+    assert calls.instrument_kwargs["separate_trace_from_runtime_context"] is True
+    assert calls.instrument_kwargs["config"].base64_image_max_length == 64_000_000
+
+
+def test_phoenix_setup_checks_endpoint_and_installs_global_handler(monkeypatch):
+    checked = []
+    handler = object()
+
+    monkeypatch.setenv("PHOENIX_URL", "http://phoenix.example:6006")
+    monkeypatch.setattr(
+        tracing_setup,
+        "_check_phoenix_reachable",
+        lambda endpoint: checked.append(endpoint) or True,
+    )
+    monkeypatch.setattr(phoenix, "arize_phoenix_callback_handler", lambda: handler)
+    monkeypatch.setattr(llama_index.core, "global_handler", None)
+
+    assert tracing_setup._setup_phoenix_tracing() is True
+    assert checked == ["http://phoenix.example:6006"]
+    assert llama_index.core.global_handler is handler
+
+
+def test_phoenix_setup_stays_disabled_when_endpoint_is_unreachable(monkeypatch):
+    monkeypatch.setenv("PHOENIX_URL", "http://phoenix.example:6006")
+    monkeypatch.setattr(
+        tracing_setup, "_check_phoenix_reachable", lambda _endpoint: False
+    )
+    monkeypatch.setattr(
+        phoenix,
+        "arize_phoenix_callback_handler",
+        lambda: (_ for _ in ()).throw(AssertionError("handler must not be created")),
+    )
+
+    assert tracing_setup._setup_phoenix_tracing() is False

--- a/uv.lock
+++ b/uv.lock
@@ -30,7 +30,7 @@ wheels = [
 
 [[package]]
 name = "aiohttp"
-version = "3.13.5"
+version = "3.14.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohappyeyeballs" },
@@ -39,61 +39,70 @@ dependencies = [
     { name = "frozenlist" },
     { name = "multidict" },
     { name = "propcache" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/9a/152096d4808df8e4268befa55fba462f440f14beab85e8ad9bf990516918/aiohttp-3.13.5.tar.gz", hash = "sha256:9d98cc980ecc96be6eb4c1994ce35d28d8b1f5e5208a23b421187d1209dbb7d1", size = 7858271, upload-time = "2026-03-31T22:01:03.343Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/d9/22ce5786ac0c1653ae8b6c23bded02c1686d11f0dbb45b31ce128e0df985/aiohttp-3.14.3.tar.gz", hash = "sha256:9491196535a88924a60afd5b5f434b5b203b6cc616250878dbdb223a8f7844bc", size = 7971213, upload-time = "2026-07-23T01:57:27.037Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/f5/a20c4ac64aeaef1679e25c9983573618ff765d7aa829fa2b84ae7573169e/aiohttp-3.13.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7ab7229b6f9b5c1ba4910d6c41a9eb11f543eadb3f384df1b4c293f4e73d44d6", size = 757513, upload-time = "2026-03-31T21:57:02.146Z" },
-    { url = "https://files.pythonhosted.org/packages/75/0a/39fa6c6b179b53fcb3e4b3d2b6d6cad0180854eda17060c7218540102bef/aiohttp-3.13.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8f14c50708bb156b3a3ca7230b3d820199d56a48e3af76fa21c2d6087190fe3d", size = 506748, upload-time = "2026-03-31T21:57:04.275Z" },
-    { url = "https://files.pythonhosted.org/packages/87/ec/e38ce072e724fd7add6243613f8d1810da084f54175353d25ccf9f9c7e5a/aiohttp-3.13.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e7d2f8616f0ff60bd332022279011776c3ac0faa0f1b463f7bb12326fbc97a1c", size = 501673, upload-time = "2026-03-31T21:57:06.208Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/ba/3bc7525d7e2beaa11b309a70d48b0d3cfc3c2089ec6a7d0820d59c657053/aiohttp-3.13.5-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2567b72e1ffc3ab25510db43f355b29eeada56c0a622e58dcdb19530eb0a3cb", size = 1763757, upload-time = "2026-03-31T21:57:07.882Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/ab/e87744cf18f1bd78263aba24924d4953b41086bd3a31d22452378e9028a0/aiohttp-3.13.5-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:fb0540c854ac9c0c5ad495908fdfd3e332d553ec731698c0e29b1877ba0d2ec6", size = 1720152, upload-time = "2026-03-31T21:57:09.946Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/f3/ed17a6f2d742af17b50bae2d152315ed1b164b07a5fd5cc1754d99e4dfa5/aiohttp-3.13.5-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c9883051c6972f58bfc4ebb2116345ee2aa151178e99c3f2b2bbe2af712abd13", size = 1818010, upload-time = "2026-03-31T21:57:12.157Z" },
-    { url = "https://files.pythonhosted.org/packages/53/06/ecbc63dc937192e2a5cb46df4d3edb21deb8225535818802f210a6ea5816/aiohttp-3.13.5-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2294172ce08a82fb7c7273485895de1fa1186cc8294cfeb6aef4af42ad261174", size = 1907251, upload-time = "2026-03-31T21:57:14.023Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/a5/0521aa32c1ddf3aa1e71dcc466be0b7db2771907a13f18cddaa45967d97b/aiohttp-3.13.5-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3a807cabd5115fb55af198b98178997a5e0e57dead43eb74a93d9c07d6d4a7dc", size = 1759969, upload-time = "2026-03-31T21:57:16.146Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/78/a38f8c9105199dd3b9706745865a8a59d0041b6be0ca0cc4b2ccf1bab374/aiohttp-3.13.5-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa6d0d932e0f39c02b80744273cd5c388a2d9bc07760a03164f229c8e02662f6", size = 1616871, upload-time = "2026-03-31T21:57:17.856Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/41/27392a61ead8ab38072105c71aa44ff891e71653fe53d576a7067da2b4e8/aiohttp-3.13.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:60869c7ac4aaabe7110f26499f3e6e5696eae98144735b12a9c3d9eae2b51a49", size = 1739844, upload-time = "2026-03-31T21:57:19.679Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/55/5564e7ae26d94f3214250009a0b1c65a0c6af4bf88924ccb6fdab901de28/aiohttp-3.13.5-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:26d2f8546f1dfa75efa50c3488215a903c0168d253b75fba4210f57ab77a0fb8", size = 1731969, upload-time = "2026-03-31T21:57:22.006Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/c5/705a3929149865fc941bcbdd1047b238e4a72bcb215a9b16b9d7a2e8d992/aiohttp-3.13.5-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f1162a1492032c82f14271e831c8f4b49f2b6078f4f5fc74de2c912fa225d51d", size = 1795193, upload-time = "2026-03-31T21:57:24.256Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/19/edabed62f718d02cff7231ca0db4ef1c72504235bc467f7b67adb1679f48/aiohttp-3.13.5-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:8b14eb3262fad0dc2f89c1a43b13727e709504972186ff6a99a3ecaa77102b6c", size = 1606477, upload-time = "2026-03-31T21:57:26.364Z" },
-    { url = "https://files.pythonhosted.org/packages/de/fc/76f80ef008675637d88d0b21584596dc27410a990b0918cb1e5776545b5b/aiohttp-3.13.5-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:ca9ac61ac6db4eb6c2a0cd1d0f7e1357647b638ccc92f7e9d8d133e71ed3c6ac", size = 1813198, upload-time = "2026-03-31T21:57:28.316Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/67/5b3ac26b80adb20ea541c487f73730dc8fa107d632c998f25bbbab98fcda/aiohttp-3.13.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:7996023b2ed59489ae4762256c8516df9820f751cf2c5da8ed2fb20ee50abab3", size = 1752321, upload-time = "2026-03-31T21:57:30.549Z" },
-    { url = "https://files.pythonhosted.org/packages/88/06/e4a2e49255ea23fa4feeb5ab092d90240d927c15e47b5b5c48dff5a9ce29/aiohttp-3.13.5-cp311-cp311-win32.whl", hash = "sha256:77dfa48c9f8013271011e51c00f8ada19851f013cde2c48fca1ba5e0caf5bb06", size = 439069, upload-time = "2026-03-31T21:57:32.388Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/43/8c7163a596dab4f8be12c190cf467a1e07e4734cf90eebb39f7f5d53fc6a/aiohttp-3.13.5-cp311-cp311-win_amd64.whl", hash = "sha256:d3a4834f221061624b8887090637db9ad4f61752001eae37d56c52fddade2dc8", size = 462859, upload-time = "2026-03-31T21:57:34.455Z" },
-    { url = "https://files.pythonhosted.org/packages/be/6f/353954c29e7dcce7cf00280a02c75f30e133c00793c7a2ed3776d7b2f426/aiohttp-3.13.5-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:023ecba036ddd840b0b19bf195bfae970083fd7024ce1ac22e9bba90464620e9", size = 748876, upload-time = "2026-03-31T21:57:36.319Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/1b/428a7c64687b3b2e9cd293186695affc0e1e54a445d0361743b231f11066/aiohttp-3.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15c933ad7920b7d9a20de151efcd05a6e38302cbf0e10c9b2acb9a42210a2416", size = 499557, upload-time = "2026-03-31T21:57:38.236Z" },
-    { url = "https://files.pythonhosted.org/packages/29/47/7be41556bfbb6917069d6a6634bb7dd5e163ba445b783a90d40f5ac7e3a7/aiohttp-3.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab2899f9fa2f9f741896ebb6fa07c4c883bfa5c7f2ddd8cf2aafa86fa981b2d2", size = 500258, upload-time = "2026-03-31T21:57:39.923Z" },
-    { url = "https://files.pythonhosted.org/packages/67/84/c9ecc5828cb0b3695856c07c0a6817a99d51e2473400f705275a2b3d9239/aiohttp-3.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a60eaa2d440cd4707696b52e40ed3e2b0f73f65be07fd0ef23b6b539c9c0b0b4", size = 1749199, upload-time = "2026-03-31T21:57:41.938Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/d3/3c6d610e66b495657622edb6ae7c7fd31b2e9086b4ec50b47897ad6042a9/aiohttp-3.13.5-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:55b3bdd3292283295774ab585160c4004f4f2f203946997f49aac032c84649e9", size = 1721013, upload-time = "2026-03-31T21:57:43.904Z" },
-    { url = "https://files.pythonhosted.org/packages/49/a0/24409c12217456df0bae7babe3b014e460b0b38a8e60753d6cb339f6556d/aiohttp-3.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2b2355dc094e5f7d45a7bb262fe7207aa0460b37a0d87027dcf21b5d890e7d5", size = 1781501, upload-time = "2026-03-31T21:57:46.285Z" },
-    { url = "https://files.pythonhosted.org/packages/98/9d/b65ec649adc5bccc008b0957a9a9c691070aeac4e41cea18559fef49958b/aiohttp-3.13.5-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b38765950832f7d728297689ad78f5f2cf79ff82487131c4d26fe6ceecdc5f8e", size = 1878981, upload-time = "2026-03-31T21:57:48.734Z" },
-    { url = "https://files.pythonhosted.org/packages/57/d8/8d44036d7eb7b6a8ec4c5494ea0c8c8b94fbc0ed3991c1a7adf230df03bf/aiohttp-3.13.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b18f31b80d5a33661e08c89e202edabf1986e9b49c42b4504371daeaa11b47c1", size = 1767934, upload-time = "2026-03-31T21:57:51.171Z" },
-    { url = "https://files.pythonhosted.org/packages/31/04/d3f8211f273356f158e3464e9e45484d3fb8c4ce5eb2f6fe9405c3273983/aiohttp-3.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:33add2463dde55c4f2d9635c6ab33ce154e5ecf322bd26d09af95c5f81cfa286", size = 1566671, upload-time = "2026-03-31T21:57:53.326Z" },
-    { url = "https://files.pythonhosted.org/packages/41/db/073e4ebe00b78e2dfcacff734291651729a62953b48933d765dc513bf798/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:327cc432fdf1356fb4fbc6fe833ad4e9f6aacb71a8acaa5f1855e4b25910e4a9", size = 1705219, upload-time = "2026-03-31T21:57:55.385Z" },
-    { url = "https://files.pythonhosted.org/packages/48/45/7dfba71a2f9fd97b15c95c06819de7eb38113d2cdb6319669195a7d64270/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:7c35b0bf0b48a70b4cb4fc5d7bed9b932532728e124874355de1a0af8ec4bc88", size = 1743049, upload-time = "2026-03-31T21:57:57.341Z" },
-    { url = "https://files.pythonhosted.org/packages/18/71/901db0061e0f717d226386a7f471bb59b19566f2cae5f0d93874b017271f/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:df23d57718f24badef8656c49743e11a89fd6f5358fa8a7b96e728fda2abf7d3", size = 1749557, upload-time = "2026-03-31T21:57:59.626Z" },
-    { url = "https://files.pythonhosted.org/packages/08/d5/41eebd16066e59cd43728fe74bce953d7402f2b4ddfdfef2c0e9f17ca274/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:02e048037a6501a5ec1f6fc9736135aec6eb8a004ce48838cb951c515f32c80b", size = 1558931, upload-time = "2026-03-31T21:58:01.972Z" },
-    { url = "https://files.pythonhosted.org/packages/30/e6/4a799798bf05740e66c3a1161079bda7a3dd8e22ca392481d7a7f9af82a6/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:31cebae8b26f8a615d2b546fee45d5ffb76852ae6450e2a03f42c9102260d6fe", size = 1774125, upload-time = "2026-03-31T21:58:04.007Z" },
-    { url = "https://files.pythonhosted.org/packages/84/63/7749337c90f92bc2cb18f9560d67aa6258c7060d1397d21529b8004fcf6f/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:888e78eb5ca55a615d285c3c09a7a91b42e9dd6fc699b166ebd5dee87c9ccf14", size = 1732427, upload-time = "2026-03-31T21:58:06.337Z" },
-    { url = "https://files.pythonhosted.org/packages/98/de/cf2f44ff98d307e72fb97d5f5bbae3bfcb442f0ea9790c0bf5c5c2331404/aiohttp-3.13.5-cp312-cp312-win32.whl", hash = "sha256:8bd3ec6376e68a41f9f95f5ed170e2fcf22d4eb27a1f8cb361d0508f6e0557f3", size = 433534, upload-time = "2026-03-31T21:58:08.712Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/ca/eadf6f9c8fa5e31d40993e3db153fb5ed0b11008ad5d9de98a95045bed84/aiohttp-3.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:110e448e02c729bcebb18c60b9214a87ba33bac4a9fa5e9a5f139938b56c6cb1", size = 460446, upload-time = "2026-03-31T21:58:10.945Z" },
-    { url = "https://files.pythonhosted.org/packages/78/e9/d76bf503005709e390122d34e15256b88f7008e246c4bdbe915cd4f1adce/aiohttp-3.13.5-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a5029cc80718bbd545123cd8fe5d15025eccaaaace5d0eeec6bd556ad6163d61", size = 742930, upload-time = "2026-03-31T21:58:13.155Z" },
-    { url = "https://files.pythonhosted.org/packages/57/00/4b7b70223deaebd9bb85984d01a764b0d7bd6526fcdc73cca83bcbe7243e/aiohttp-3.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4bb6bf5811620003614076bdc807ef3b5e38244f9d25ca5fe888eaccea2a9832", size = 496927, upload-time = "2026-03-31T21:58:15.073Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/f5/0fb20fb49f8efdcdce6cd8127604ad2c503e754a8f139f5e02b01626523f/aiohttp-3.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a84792f8631bf5a94e52d9cc881c0b824ab42717165a5579c760b830d9392ac9", size = 497141, upload-time = "2026-03-31T21:58:17.009Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/86/b7c870053e36a94e8951b803cb5b909bfbc9b90ca941527f5fcafbf6b0fa/aiohttp-3.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57653eac22c6a4c13eb22ecf4d673d64a12f266e72785ab1c8b8e5940d0e8090", size = 1732476, upload-time = "2026-03-31T21:58:18.925Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/e5/4e161f84f98d80c03a238671b4136e6530453d65262867d989bbe78244d0/aiohttp-3.13.5-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e5e5f7debc7a57af53fdf5c5009f9391d9f4c12867049d509bf7bb164a6e295b", size = 1706507, upload-time = "2026-03-31T21:58:21.094Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/56/ea11a9f01518bd5a2a2fcee869d248c4b8a0cfa0bb13401574fa31adf4d4/aiohttp-3.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c719f65bebcdf6716f10e9eff80d27567f7892d8988c06de12bbbd39307c6e3a", size = 1773465, upload-time = "2026-03-31T21:58:23.159Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/40/333ca27fb74b0383f17c90570c748f7582501507307350a79d9f9f3c6eb1/aiohttp-3.13.5-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d97f93fdae594d886c5a866636397e2bcab146fd7a132fd6bb9ce182224452f8", size = 1873523, upload-time = "2026-03-31T21:58:25.59Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/d2/e2f77eef1acb7111405433c707dc735e63f67a56e176e72e9e7a2cd3f493/aiohttp-3.13.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3df334e39d4c2f899a914f1dba283c1aadc311790733f705182998c6f7cae665", size = 1754113, upload-time = "2026-03-31T21:58:27.624Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/56/3f653d7f53c89669301ec9e42c95233e2a0c0a6dd051269e6e678db4fdb0/aiohttp-3.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fe6970addfea9e5e081401bcbadf865d2b6da045472f58af08427e108d618540", size = 1562351, upload-time = "2026-03-31T21:58:29.918Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/a6/9b3e91eb8ae791cce4ee736da02211c85c6f835f1bdfac0594a8a3b7018c/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7becdf835feff2f4f335d7477f121af787e3504b48b449ff737afb35869ba7bb", size = 1693205, upload-time = "2026-03-31T21:58:32.214Z" },
-    { url = "https://files.pythonhosted.org/packages/98/fc/bfb437a99a2fcebd6b6eaec609571954de2ed424f01c352f4b5504371dd3/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:676e5651705ad5d8a70aeb8eb6936c436d8ebbd56e63436cb7dd9bb36d2a9a46", size = 1730618, upload-time = "2026-03-31T21:58:34.728Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/b6/c8534862126191a034f68153194c389addc285a0f1347d85096d349bbc15/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:9b16c653d38eb1a611cc898c41e76859ca27f119d25b53c12875fd0474ae31a8", size = 1745185, upload-time = "2026-03-31T21:58:36.909Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/93/4ca8ee2ef5236e2707e0fd5fecb10ce214aee1ff4ab307af9c558bda3b37/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:999802d5fa0389f58decd24b537c54aa63c01c3219ce17d1214cbda3c2b22d2d", size = 1557311, upload-time = "2026-03-31T21:58:39.38Z" },
-    { url = "https://files.pythonhosted.org/packages/57/ae/76177b15f18c5f5d094f19901d284025db28eccc5ae374d1d254181d33f4/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:ec707059ee75732b1ba130ed5f9580fe10ff75180c812bc267ded039db5128c6", size = 1773147, upload-time = "2026-03-31T21:58:41.476Z" },
-    { url = "https://files.pythonhosted.org/packages/01/a4/62f05a0a98d88af59d93b7fcac564e5f18f513cb7471696ac286db970d6a/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2d6d44a5b48132053c2f6cd5c8cb14bc67e99a63594e336b0f2af81e94d5530c", size = 1730356, upload-time = "2026-03-31T21:58:44.049Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/85/fc8601f59dfa8c9523808281f2da571f8b4699685f9809a228adcc90838d/aiohttp-3.13.5-cp313-cp313-win32.whl", hash = "sha256:329f292ed14d38a6c4c435e465f48bebb47479fd676a0411936cc371643225cc", size = 432637, upload-time = "2026-03-31T21:58:46.167Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/1b/ac685a8882896acf0f6b31d689e3792199cfe7aba37969fa91da63a7fa27/aiohttp-3.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:69f571de7500e0557801c0b51f4780482c0ec5fe2ac851af5a92cfce1af1cb83", size = 458896, upload-time = "2026-03-31T21:58:48.119Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/5c/b3e4ff8ad43a8afef9602c5e90285936da1beaea8b029016b793891f03c3/aiohttp-3.14.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e568e14940c09955aa51f4e645b6daa18a581c5dcfcd73744dcc86a856e3ced3", size = 764250, upload-time = "2026-07-23T01:52:48.525Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/da/f1b384465e51449d844056b75070461da03a9a23e6c1747003695bf4172a/aiohttp-3.14.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:54cfcdee2770dac994417cbb0ee1f3eb0e7cb6b30c79bf44f2c02ff79ec5124a", size = 516281, upload-time = "2026-07-23T01:52:51.047Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/3f/01264f820ee2e3712a827892b1cd6ff80f3300c1fcbffbb45714a915d47a/aiohttp-3.14.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:21c016079415ed3fd676963e9793700a566d85dbbd6bfc564b9b2d209147dcc8", size = 514742, upload-time = "2026-07-23T01:52:53.779Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8d/a71c6f2db52ac1ed142b133f7feddaa6b70539c3f4de24d7e226c95b794c/aiohttp-3.14.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d6088ec9894113802bddb3c09e974929aed2c7b3a8c456219b8aab4481f1a239", size = 1780613, upload-time = "2026-07-23T01:52:56.948Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/11/3dd9b3fb3a170f6ec9011b5291d876a6fab4086714c9e158600edf01b4fd/aiohttp-3.14.3-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:16ea7e24c309fb7c0bbd505d149abe4fe4dccfb8db911db7dbec0921bc889a6f", size = 1737688, upload-time = "2026-07-23T01:52:59.294Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/3e/834c26918be7d88068822b40e0db30fca50b5f4fe79104aa16a93f1d74e6/aiohttp-3.14.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:56f355e79f71aef2a85c80305cc915f894b170dba76de5fe84f6351939b83c06", size = 1845742, upload-time = "2026-07-23T01:53:01.641Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c9/49ab8572df7d66bc13d11e31f781292badb04180dd87ba98733066c6aed7/aiohttp-3.14.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:18c441d0a8fca6de8d1f546849b9f0ab20d435993e2c5b59562b2fae6be2f929", size = 1928412, upload-time = "2026-07-23T01:53:04.018Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/2b8f0c0ce09c87a1daf80fd483431b56b1435d3f62789bc86f572e1245de/aiohttp-3.14.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:53e7b4ce82b54a8bcc71b3b67a5cbd177ca1d7f592cbc92cd38b7349f73482db", size = 1786220, upload-time = "2026-07-23T01:53:06.481Z" },
+    { url = "https://files.pythonhosted.org/packages/85/00/9c45f81de11710460edfa1dc81317b6e882703b160926c879a9d20da9fcc/aiohttp-3.14.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f55119f7bf25f49ed210f6096090715da24f2943c62102448915fde3c62877ce", size = 1637231, upload-time = "2026-07-23T01:53:10.258Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ce/967d628e910756f3539c6107cb7844a1b69440dcb3029a5ee7871b09ab63/aiohttp-3.14.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9aa6e61fdf20105c4144e755bd586008ff450791d67b1c8146fdc15959c4d51c", size = 1753161, upload-time = "2026-07-23T01:53:13.817Z" },
+    { url = "https://files.pythonhosted.org/packages/11/b2/0c3d4114f0aee4f580f5b3b4eb71b24d7a23b834ea506a4dfebe76513f35/aiohttp-3.14.3-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:ccd4893707b3e2a13e39c90d43cf80edf2e4d0457935bcc103bf2346214c3f15", size = 1756356, upload-time = "2026-07-23T01:53:16.211Z" },
+    { url = "https://files.pythonhosted.org/packages/63/5d/99e7d91c82f1399d1ae2a854e080bd1493fbc31e5e959dbc4ec33dac3bec/aiohttp-3.14.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:b2466434105a4e03113c36ec775cc2ebe6676b62eae326fa670bb607ef788c1c", size = 1819846, upload-time = "2026-07-23T01:53:18.289Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/05/d5e1cb6480eeffd3f901d40a2c5e2d1e7effdc797837da3b490272699f13/aiohttp-3.14.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:ba59d59aba08ac02fc03b0c8983ccd5ee39a199d0552ce9e6d2b4845b34d59ae", size = 1628531, upload-time = "2026-07-23T01:53:23.86Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/90/b934682bcaefae18a9e04f3dff5b68522ba810906358ae5029b68110ea3b/aiohttp-3.14.3-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:ed099d105449c4f9e84f24af203cd131349d4761d8813fa7e02c32e7128cd910", size = 1832712, upload-time = "2026-07-23T01:53:27.551Z" },
+    { url = "https://files.pythonhosted.org/packages/21/df/6061679faaf81fac746e7307c7adb71e858071a5d34c27583afefc64f543/aiohttp-3.14.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:152516815ef926786a0b6ae2b8f1fd2e0c71582dee0b435636865316fd4891b7", size = 1775014, upload-time = "2026-07-23T01:53:30.223Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/1d/f854878bbc69b88faefe924b619a34a6f59ec05fd387c77690667eaa75eb/aiohttp-3.14.3-cp311-cp311-win32.whl", hash = "sha256:a4af35c443e0b1a1bd6a8af3f3485d7fda15c142751a00f3ff8090f0b93346fa", size = 456006, upload-time = "2026-07-23T01:53:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/73/0c/2af9d1674baccd1dbd47282a93d660a22e57ef6167c856deb24b4214fbab/aiohttp-3.14.3-cp311-cp311-win_amd64.whl", hash = "sha256:e1e74298bab6ee0d6e749ed4fd1901c7e604bdda32c03d787a2cc71c46d0433d", size = 481069, upload-time = "2026-07-23T01:53:39.673Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/76/88401ff3fc95e85c5fc38d588f36f55e61ecb64343b2bc8d69326f453cc0/aiohttp-3.14.3-cp311-cp311-win_arm64.whl", hash = "sha256:03cd2bde3d7f085b64e549c985f4bb928cad7e8ecf5323bfca320db548d81b39", size = 453021, upload-time = "2026-07-23T01:53:43.749Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d4/eb96299230e20acf2efae207cb8d69051f1f68e357e5ea5e479bf6fb097a/aiohttp-3.14.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:39aded8c7f3b935b54aab1d8d73c70ec0ee2d3ec3b943e0e86611bc150ba47f5", size = 754690, upload-time = "2026-07-23T01:53:47.332Z" },
+    { url = "https://files.pythonhosted.org/packages/88/11/e7a70a209eb9a067c0d3212b518a0134e3484f5178c7533878b6b514d469/aiohttp-3.14.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5bcb6ff3fdab1258a192679ff1a05d44f59626430aa05cd1a9d2447423599228", size = 509484, upload-time = "2026-07-23T01:53:51.159Z" },
+    { url = "https://files.pythonhosted.org/packages/30/07/4bbc222cc8dbe31d4c3e8a5baad2286e4d42026ac0c570027b89afce6344/aiohttp-3.14.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:617105e2c3018ee38d0c8ce5ee3c84f621a6d8b9f723202aacaff28449ca91ee", size = 511949, upload-time = "2026-07-23T01:53:55.083Z" },
+    { url = "https://files.pythonhosted.org/packages/54/b9/42e74c46b7b7c794b995bbc1f573fb48950c38b19d8600c62a6804ee2d67/aiohttp-3.14.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f631fe87a6f30df5fbe6d79640b25e4cffb38c31c7fb6f10871517b84b0f8c1a", size = 1765282, upload-time = "2026-07-23T01:53:59.662Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ed/62bc4d74363ad346d518e0720363a949f63e2e23439a79eb5813d4d29bb3/aiohttp-3.14.3-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a94dbaae5ae27bd849c93570669bff91e0510f33a80805738e3de72a7be0447b", size = 1741511, upload-time = "2026-07-23T01:54:04.063Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9f/181e8a8bc79e47d13c7fc4540bd7a3b729d9505609c61f392a8dd2fbfe55/aiohttp-3.14.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8f2f1c4c032c7cedd7d8da6f54c97b70266c6570c3108d3fdffee7188bb70529", size = 1810680, upload-time = "2026-07-23T01:54:09.882Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/9a/dec94d6ad694552fe3424e3f1928d7a606a5d9d9433a04e7ecdd9d38ae7f/aiohttp-3.14.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ea05e1f97ceea523942d9b2a7d7c0359d781d683d6b043f5943a602b14da4787", size = 1905646, upload-time = "2026-07-23T01:54:13.475Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b7/7cd31f29d6055bd711ae6e669367fba6f5ae9de463910a793e30556a8db7/aiohttp-3.14.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:543906c127fb1d929b95076db19b83fa2d46751006ff1e23b093aa5ac4d8db42", size = 1792122, upload-time = "2026-07-23T01:54:15.752Z" },
+    { url = "https://files.pythonhosted.org/packages/66/73/10b1ef93afa61f4963c746257b70ced619cf31a4798671de5fdb2608501d/aiohttp-3.14.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0a5ff2dfbb9ce645fa5b8ef3e02c6c0b9cc3f6030ff863d0c51fffc50cb5541b", size = 1591127, upload-time = "2026-07-23T01:54:19.489Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ed/3b203fa6de1b338c14acdc06bf6ca9b043b7944f005966958c2ced932cde/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:041badb8f84396357c4d3ad26de6afd7a32b112f43d3c63045c0c8278cfd2043", size = 1725210, upload-time = "2026-07-23T01:54:24.129Z" },
+    { url = "https://files.pythonhosted.org/packages/28/b7/1c2aab8c706436dcc28598452488ac9cd7c409da815237c28c27d58993e6/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:530125ee1163c4219af35dc3aa1206e541e7b31b6efc1a3f93b70a136f65d427", size = 1764848, upload-time = "2026-07-23T01:54:27.973Z" },
+    { url = "https://files.pythonhosted.org/packages/54/50/94c28f08b131c4bf10984ea2c7a536c9920608bb2d6e7f95642c30cc87b7/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c8653fd547c93a61aadc612007790f5555cdd18946fa48cf45e26d8ea4ea473d", size = 1777102, upload-time = "2026-07-23T01:54:31.775Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d4/e7d09ba7d345fb2d74440fd2fa033c5e079fac05552927705986f41a364f/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:89176250f686cb9853c0fb7ead90e639e915b84a6f43eedc2a4e7ec21f1037f0", size = 1580205, upload-time = "2026-07-23T01:54:34.518Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/84/072a91d68e1e1eb587985b54baab94221277f877e8ef274fc213a0ceae28/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:3a26434dafe408229ff3403458ca58de24fb51936504decac49ce6755f77e59d", size = 1797219, upload-time = "2026-07-23T01:54:36.995Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/eb/aad34e897e668424d6e995da5dff8a4a09af93363d3392488772957a63aa/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d1558173930a5a8d3069cee5c92fc91c87c4dbcb099debbb3622053717145a19", size = 1768629, upload-time = "2026-07-23T01:54:40.103Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/2b/6bb88ddba0fecd9122aa3ebcad25996cf6c083a4a7040dbb3a4f97972af6/aiohttp-3.14.3-cp312-cp312-win32.whl", hash = "sha256:16100ad3ab8d649fdfbee87602d9d2dcdca9df0b9eda8a1b5fdc0d41f96da559", size = 451481, upload-time = "2026-07-23T01:54:42.547Z" },
+    { url = "https://files.pythonhosted.org/packages/76/9b/f2f8f108da17ecef2cc3efc424e8b7ad3782b1a8360f7b8eae8ced84f6ea/aiohttp-3.14.3-cp312-cp312-win_amd64.whl", hash = "sha256:33a2d7c28d33797a2e99923dffa63f83d908a19b6bf26cfe80fa790aa5e1a75a", size = 476845, upload-time = "2026-07-23T01:54:44.853Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/44/28dac80a8941b604f4da10ce21097614ca1bf905ce93dca28d8d7de9c1e7/aiohttp-3.14.3-cp312-cp312-win_arm64.whl", hash = "sha256:362a3fd481769cac1a824514bcd86fda51c65e8fe6e051099e008fddde6db17c", size = 448050, upload-time = "2026-07-23T01:54:47.087Z" },
+    { url = "https://files.pythonhosted.org/packages/57/be/5afd201cc0ab139029aadb75392efe85a293403d9dd3a3226161c21ce00c/aiohttp-3.14.3-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:2e9878ae68e4a5f1c0abe4dd497dbc3d51946f5837b56759e2a02e78fa90ef86", size = 506269, upload-time = "2026-07-23T01:54:49.075Z" },
+    { url = "https://files.pythonhosted.org/packages/22/09/dec8189d62b45ade009f6792a2264b942a90cb88aeaf181239933cd72c3c/aiohttp-3.14.3-cp313-cp313-android_21_x86_64.whl", hash = "sha256:f3d2669fe7dec7fc359ecdb5984b29b50d85d5d00f8c1cb61de4f4a24ee42627", size = 515166, upload-time = "2026-07-23T01:54:51.894Z" },
+    { url = "https://files.pythonhosted.org/packages/28/24/2854869d29ed8a8b19d74f9ec6629515f7e04d02dd329d9d179201e58e47/aiohttp-3.14.3-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:cc7cb243a68167172f48c1fd43cee91ec4b1d40cefd190edd43369d1a6bc9c82", size = 486263, upload-time = "2026-07-23T01:54:54.223Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/dd/57187c8be2a35aea65eaee3bd2c3dcbbcf0204f5106c89637e3610380cd1/aiohttp-3.14.3-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:78253b573e6ffab5028924fc98bc281aae05445969982a10864bc360dea2016c", size = 492299, upload-time = "2026-07-23T01:54:56.236Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/11/06ae6ed8f0d414edf4068861e233d8fe23ee699bfd4b3ceb8663db948a62/aiohttp-3.14.3-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:7041d52c3a7fa20c9e8c182b534704abb19502c8bdcbde7ab23bfda6f642394f", size = 502235, upload-time = "2026-07-23T01:54:58.377Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/a3/559639c34a345d2cf7c52dff6838119f2eaf29eb508227b5b83f573af813/aiohttp-3.14.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ac74facc01463f138b0da5580329cfcc82818dea5656e83ddcd11268fc12ff80", size = 750883, upload-time = "2026-07-23T01:55:00.65Z" },
+    { url = "https://files.pythonhosted.org/packages/91/cd/41e131f13afd1e7b0172a9d9eda085ef90eb8439f41f0d279db81ed3ae60/aiohttp-3.14.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d6218d92e450824e9b4881f44e8c09f1853b490f9a64130801024a4793b1b3b0", size = 508473, upload-time = "2026-07-23T01:55:02.945Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/6b/e7f13410d391c6e55b4c007a8de024355389d7d459e3d64c42b2d33617e5/aiohttp-3.14.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:11fb37ef075669eee52ab1928fbf6e1741fada40409fa309ebde9607a962aebf", size = 509190, upload-time = "2026-07-23T01:55:05.173Z" },
+    { url = "https://files.pythonhosted.org/packages/97/21/6464573e53d69672cc1eada3e5c5cb2d2efa82701e8305a0f2047a576967/aiohttp-3.14.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55bdcc472aafe2de4a253045cc128007a64f1e0264fb675791e132ea5edaa3bd", size = 1761478, upload-time = "2026-07-23T01:55:07.383Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/81/d217043a4c17fbce360905e3b2bdd20139ebc9a2de836d035d179c4da006/aiohttp-3.14.3-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c39846c3aad97a8530c89d7a3869a8f8e9e3762c6ac0504481e5c80948f7e807", size = 1735092, upload-time = "2026-07-23T01:55:09.803Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/66/e13a02d0eeb1a9a502402a977abb4e4abff9fe4051c26f80558c57a7c975/aiohttp-3.14.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5895ef58c4620afe02fa16044f023dc4dafec08158f9d08874a46a7dbc0341b8", size = 1800546, upload-time = "2026-07-23T01:55:12.012Z" },
+    { url = "https://files.pythonhosted.org/packages/26/5e/57d42fca1d18cb5acc1cad945d017fabc5d6ae71d8a08ad66be8dc3ee544/aiohttp-3.14.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa9467a8113aa69d3d7c55a70ef0b7c636010a40993f3df9d9d0d73b3eb7ef24", size = 1895250, upload-time = "2026-07-23T01:55:14.357Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/1c/7da8d08e74d56f00070822f9638ff3f1c563f8ad87d1efa996c87bfc8644/aiohttp-3.14.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d7d2deec16eeedf55f2c7cf75b521ea3856a5177e123844f8fd0f114ce252cb5", size = 1789289, upload-time = "2026-07-23T01:55:16.668Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/0f/cf16bcf56896981c1a0319f5d5db9337994b5165730c48a8fa07e9b34be6/aiohttp-3.14.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dd54d0e8717de95939766febac482ac0474d8ac3b048115f9f2b1d23a16e7db4", size = 1586706, upload-time = "2026-07-23T01:55:18.913Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/6f/76eac12a7f2480e1e304f842efdb07db33256b0d9165b866b6ef0806c202/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:df82f3787c940c94986b34222d59c9e38843fba85139f36e85255a82ad5355a9", size = 1724652, upload-time = "2026-07-23T01:55:21.296Z" },
+    { url = "https://files.pythonhosted.org/packages/39/b6/19c8c592baeeb94b75f966547d40c02ac7590902306ec5863d5c027cf506/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:42a67efc36300d052fb4508a53e8b6901b9284b599ae63945c377569c5fcc1e1", size = 1756239, upload-time = "2026-07-23T01:55:23.705Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c9/4e9383150296f97f873b680c4de8fb2cd88608fb9f48c79edcb111611abc/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7a75aa63cbf9b21cfaf60dc2657e19df2c2867d91707d653fee171ffeedd1371", size = 1769161, upload-time = "2026-07-23T01:55:26.082Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1e/147bdc6cc5de5f3ab011be8bf5d6e786633249f22c20bae06f85e45f5387/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:e92eb8acc45eb6a9f4935071a77edf5b85cc6f8dfad5cd99e97653c26593cdde", size = 1578759, upload-time = "2026-07-23T01:55:28.846Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/31/78388a9d6040ece2e11df62ea229a822cf5e52d238374b220ae9975b2623/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:b014a6ed7cf912e787149fdc529166d3ceabac23f26efeea3158c9aba2354e7e", size = 1792025, upload-time = "2026-07-23T01:55:31.457Z" },
+    { url = "https://files.pythonhosted.org/packages/03/51/a3d29fdf2c25d796746af8ad6fe56a45d6256c38b0a8a2ed752e1160b3a2/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3d4f72af88ac2474bb5bca640030320e3d38a0163a1d7533500e87be458eef71", size = 1768477, upload-time = "2026-07-23T01:55:33.87Z" },
+    { url = "https://files.pythonhosted.org/packages/29/a6/442e18b5afeade534d877a2dc3c3e392aff8d49787890b0cf84790410267/aiohttp-3.14.3-cp313-cp313-win32.whl", hash = "sha256:5f08ec777f35ee70720233b8b9811d3bb5d728137f30ac91b7457709c3261ac0", size = 451069, upload-time = "2026-07-23T01:55:36.121Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/69/3d876ac02659f271cf7f6769f14a8e3de5b6e888ed8b5a7e998086a4cec8/aiohttp-3.14.3-cp313-cp313-win_amd64.whl", hash = "sha256:dff9461ec275f22135650d5ba4b4931a11f3958df7dfbb8db630000d4dee0883", size = 476518, upload-time = "2026-07-23T01:55:38.303Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/0e/50d6e6471cd31edce8b282bdec59375a3a69124d8a989a0b1313355cae52/aiohttp-3.14.3-cp313-cp313-win_arm64.whl", hash = "sha256:ddcac3c6b382e81f1dd0499199d4136b877beb4cb5ef770bbbfba56c4b8f55d2", size = 447676, upload-time = "2026-07-23T01:55:40.451Z" },
 ]
 
 [[package]]
@@ -213,7 +222,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/e5/d0/432fb6fb1fe48aa0e
 
 [[package]]
 name = "arize-phoenix"
-version = "13.21.0"
+version = "14.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aioitertools" },
@@ -244,7 +253,6 @@ dependencies = [
     { name = "orjson" },
     { name = "pandas" },
     { name = "prometheus-client" },
-    { name = "protobuf" },
     { name = "psutil" },
     { name = "pyarrow" },
     { name = "pydantic" },
@@ -263,9 +271,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/e2/6b73bf982786317ec6520456957fb5b37a25ac1ca8f2fc4ad822f58d1fb4/arize_phoenix-13.21.0.tar.gz", hash = "sha256:1a6680cbebb69d667f2bda33b76b872889cae2353c10a2462f33aa8308f5c39e", size = 4600129, upload-time = "2026-04-01T00:22:54.375Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/ed/7d723a8f9b25e0e8835bcdb341913e22e355150f6d452cb2ac6cc5041b70/arize_phoenix-14.4.0.tar.gz", hash = "sha256:c534d5782f5f411e77f32a69f217b2b14d732ee7f1f12788afa53332ec0416e5", size = 4694571, upload-time = "2026-04-14T15:57:31.606Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/bb/f30d1a9a7b52250e5a8f103008ead85d9fe9f4c3def605c709b743093bd3/arize_phoenix-13.21.0-py3-none-any.whl", hash = "sha256:07e64b6f88a93a2e5fab22466fae2b7198fcb865c18f9c296f495876bb21797c", size = 4935429, upload-time = "2026-04-01T00:22:51.86Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/a3/197dd2da5882edd40529fb04f95237cdbf0e2c36a1abef5b75926dd6b72c/arize_phoenix-14.4.0-py3-none-any.whl", hash = "sha256:b5d7f1f1d8207ebb8292ea42d9941a4125d81cfaacff3d8d3b4baf72e4ce9f85", size = 5031065, upload-time = "2026-04-14T15:57:28.927Z" },
 ]
 
 [[package]]
@@ -387,7 +395,7 @@ wheels = [
 
 [[package]]
 name = "banks"
-version = "2.4.1"
+version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecated" },
@@ -397,14 +405,14 @@ dependencies = [
     { name = "platformdirs" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/5d/54c79aaaa9aa1278af24cae98d81d6ef635ad840f046bc2ccb5041ddeb1b/banks-2.4.1.tar.gz", hash = "sha256:8cbf1553f14c44d4f7e9c2064ad9212ce53ee4da000b2f8308d548b60db56655", size = 188033, upload-time = "2026-02-17T11:21:14.855Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/f0/ce5b3105a8551fdcedb509ab5340066247b3cd1b28e79f9296be2d6d3bf4/banks-2.5.0.tar.gz", hash = "sha256:fdd4fd54b84dbe31cb51a1173c960697c73d683a52fb0b1d1957a557a8d6fcc8", size = 194585, upload-time = "2026-08-08T15:54:16.548Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/5a/f38b49e8b225b0c774e97c9495e52ab9ccdf6d82bde68c513bd736820eb2/banks-2.4.1-py3-none-any.whl", hash = "sha256:40e6d9b6e9b69fb403fa31f2853b3297e4919c1b6f2179b2119d2d4473c6ed13", size = 35032, upload-time = "2026-02-17T11:21:13.236Z" },
+    { url = "https://files.pythonhosted.org/packages/07/9c/7dc7b15cecc03baa47d413b2599487b1fab270169b00feaa5e74978845f3/banks-2.5.0-py3-none-any.whl", hash = "sha256:8804c58f23e41a5aabe9ecfdf64235cdf1d5f3b16ad95ec2a54b6dc738dc1dfc", size = 38620, upload-time = "2026-08-08T15:54:15.505Z" },
 ]
 
 [[package]]
 name = "black"
-version = "25.9.0"
+version = "26.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -414,21 +422,24 @@ dependencies = [
     { name = "platformdirs" },
     { name = "pytokens" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/43/20b5c90612d7bdb2bdbcceeb53d588acca3bb8f0e4c5d5c751a2c8fdd55a/black-25.9.0.tar.gz", hash = "sha256:0474bca9a0dd1b51791fcc507a4e02078a1c63f6d4e4ae5544b9848c7adfb619", size = 648393, upload-time = "2025-09-19T00:27:37.758Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/37/5628dd55bf2b34257fc7603f0fe97c40e3aaf24265f416a9c85c95ca1436/black-26.5.1.tar.gz", hash = "sha256:dd321f668053961824bcc1be1cc1df748b2d7e4fa28086b08331e577b0100a73", size = 679439, upload-time = "2026-05-18T16:53:36.107Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/f4/7531d4a336d2d4ac6cc101662184c8e7d068b548d35d874415ed9f4116ef/black-25.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:456386fe87bad41b806d53c062e2974615825c7a52159cde7ccaeb0695fa28fa", size = 1698727, upload-time = "2025-09-19T00:31:14.264Z" },
-    { url = "https://files.pythonhosted.org/packages/28/f9/66f26bfbbf84b949cc77a41a43e138d83b109502cd9c52dfc94070ca51f2/black-25.9.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a16b14a44c1af60a210d8da28e108e13e75a284bf21a9afa6b4571f96ab8bb9d", size = 1555679, upload-time = "2025-09-19T00:31:29.265Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/59/61475115906052f415f518a648a9ac679d7afbc8da1c16f8fdf68a8cebed/black-25.9.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aaf319612536d502fdd0e88ce52d8f1352b2c0a955cc2798f79eeca9d3af0608", size = 1617453, upload-time = "2025-09-19T00:30:42.24Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/5b/20fd5c884d14550c911e4fb1b0dae00d4abb60a4f3876b449c4d3a9141d5/black-25.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:c0372a93e16b3954208417bfe448e09b0de5cc721d521866cd9e0acac3c04a1f", size = 1333655, upload-time = "2025-09-19T00:30:56.715Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/8e/319cfe6c82f7e2d5bfb4d3353c6cc85b523d677ff59edc61fdb9ee275234/black-25.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:1b9dc70c21ef8b43248f1d86aedd2aaf75ae110b958a7909ad8463c4aa0880b0", size = 1742012, upload-time = "2025-09-19T00:33:08.678Z" },
-    { url = "https://files.pythonhosted.org/packages/94/cc/f562fe5d0a40cd2a4e6ae3f685e4c36e365b1f7e494af99c26ff7f28117f/black-25.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8e46eecf65a095fa62e53245ae2795c90bdecabd53b50c448d0a8bcd0d2e74c4", size = 1581421, upload-time = "2025-09-19T00:35:25.937Z" },
-    { url = "https://files.pythonhosted.org/packages/84/67/6db6dff1ebc8965fd7661498aea0da5d7301074b85bba8606a28f47ede4d/black-25.9.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9101ee58ddc2442199a25cb648d46ba22cd580b00ca4b44234a324e3ec7a0f7e", size = 1655619, upload-time = "2025-09-19T00:30:49.241Z" },
-    { url = "https://files.pythonhosted.org/packages/10/10/3faef9aa2a730306cf469d76f7f155a8cc1f66e74781298df0ba31f8b4c8/black-25.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:77e7060a00c5ec4b3367c55f39cf9b06e68965a4f2e61cecacd6d0d9b7ec945a", size = 1342481, upload-time = "2025-09-19T00:31:29.625Z" },
-    { url = "https://files.pythonhosted.org/packages/48/99/3acfea65f5e79f45472c45f87ec13037b506522719cd9d4ac86484ff51ac/black-25.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0172a012f725b792c358d57fe7b6b6e8e67375dd157f64fa7a3097b3ed3e2175", size = 1742165, upload-time = "2025-09-19T00:34:10.402Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/18/799285282c8236a79f25d590f0222dbd6850e14b060dfaa3e720241fd772/black-25.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3bec74ee60f8dfef564b573a96b8930f7b6a538e846123d5ad77ba14a8d7a64f", size = 1581259, upload-time = "2025-09-19T00:32:49.685Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/ce/883ec4b6303acdeca93ee06b7622f1fa383c6b3765294824165d49b1a86b/black-25.9.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b756fc75871cb1bcac5499552d771822fd9db5a2bb8db2a7247936ca48f39831", size = 1655583, upload-time = "2025-09-19T00:30:44.505Z" },
-    { url = "https://files.pythonhosted.org/packages/21/17/5c253aa80a0639ccc427a5c7144534b661505ae2b5a10b77ebe13fa25334/black-25.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:846d58e3ce7879ec1ffe816bb9df6d006cd9590515ed5d17db14e17666b2b357", size = 1343428, upload-time = "2025-09-19T00:32:13.839Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/46/863c90dcd3f9d41b109b7f19032ae0db021f0b2a81482ba0a1e28c84de86/black-25.9.0-py3-none-any.whl", hash = "sha256:474b34c1342cdc157d307b56c4c65bce916480c4a8f6551fdc6bf9b486a7c4ae", size = 203363, upload-time = "2025-09-19T00:27:35.724Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/96/3c3e09f09f44a37aac36b178a279cd19aa7001bd796187a7b162a294c81f/black-26.5.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:96ae2c733b2aabdd9986e2c5df628ff3473676cd1c5faded1ff496cf6d74083c", size = 1970639, upload-time = "2026-05-18T17:05:11.461Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ea/5ad117b9ee3ecd933c712bcbae610006e5b7cc9f41c526cd7ed3b6c4124c/black-26.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0e48b87e03bf109288e55cfceadcfa15ff5470aca2851a851950ed2926f450d7", size = 1792130, upload-time = "2026-05-18T17:05:12.983Z" },
+    { url = "https://files.pythonhosted.org/packages/06/3a/7c448bc623fcdfa96672531beb5a616ea5e64f6975955254d7731ffb0ad9/black-26.5.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5119fa92ae61f786e8c3662fd60aece1d0a2dd5cca5d0c79417a95e7a4272a59", size = 1846134, upload-time = "2026-05-18T17:05:14.506Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5b/0b39b3a5917f0657ac014ad2edb58c139553a478adfe7f817abf1622ff6e/black-26.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:30d3c14661f2792e9142cce3eeeb1cbc175b3eb5f733be0c8eeb99651e52b0c3", size = 1478883, upload-time = "2026-05-18T17:05:16.542Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/48/dc222692e0f95030db1bbfb6c857e76858bad09058221ea7aae815255327/black-26.5.1-cp311-cp311-win_arm64.whl", hash = "sha256:1ef92b76f7733f282fd096ea406200b5a286c42947412b0eaff3a74e3616cefe", size = 1277776, upload-time = "2026-05-18T17:05:18.029Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/7744b906703228264ef73bdd534df88ec1ef3de45c4e78f6d31b9e32d0c9/black-26.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4ad6fa01f941920f54f2bbb35f3df7673428a0ef98a0b0840c2eaef3b110efa8", size = 2012518, upload-time = "2026-05-18T17:05:20.108Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/c0/c5a3b1636dfd09c42534f2b3cf33506814f6d3e066fb0879ffa16c1ae860/black-26.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3915f256e75a2d7cf88d8953d37f780455dc586cc72dee059c528fe77f581217", size = 1816016, upload-time = "2026-05-18T17:05:21.84Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/0e/36044316b65ca471d3bb6d3703fd06fb50c6b727c3562f6a5a3153634f88/black-26.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d98d4137277c75dfb898ec8d846c4fd68ba1e9cf77f95e2865c203dc18f4c3d", size = 1884150, upload-time = "2026-05-18T17:05:23.546Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/33/dafc5808c2af43672912111d7c3354af1615f7e2be3bed7a878461abbe4d/black-26.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:a1dca32d9f1784af512a13410ec204c6f7f0aa9797a111c42e1c03449821c264", size = 1486825, upload-time = "2026-05-18T17:05:25.004Z" },
+    { url = "https://files.pythonhosted.org/packages/82/14/b965ee6ad2a311f28bdbf692def3ee9848d2ae289dab28b27657fcee3e78/black-26.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:1037d5ac7b7b310b2632ad867ec8d0e4c4819dcdb0b820f63135da746a24e418", size = 1288646, upload-time = "2026-05-18T17:05:26.477Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/5c/c384363980e11e25ca6b93205949bb331fbf35f4e0dbec376dfa6326cec8/black-26.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2b36cf2ddf5566e205f6535f782a62194a184d33e175b64ae8c40b1737522be3", size = 2009020, upload-time = "2026-05-18T17:05:28.132Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/df/9f31c5e0babbfed77d505fc5d120beb98b21b33feaeded3924ea941fe360/black-26.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f7ea64ebfa01b50f693508fc39f875e264446d3b097088f84f203b9d09618a0", size = 1813335, upload-time = "2026-05-18T17:05:31.266Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/24/8e7b9a2fa61b0afd82209efe937557d180a1fa055bd7f6161eb9defc3719/black-26.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecb3e624844c798144e9bd986954e0adc81d8911a1f30f375e1252fe26e8c294", size = 1881614, upload-time = "2026-05-18T17:05:32.718Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ad/b4e0d9365ba8ac34f6bbab62a4b1b2dd5d618fac3fa1b8db968c844201b5/black-26.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:e1a26503279b6b310669fb0b219c39e4820b77e8189fe80f522bb511f247db0a", size = 1488925, upload-time = "2026-05-18T17:05:34.259Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/4b/652b859bf5df88a751c30451b09338f7fd26a77d1271c666992f836b7711/black-26.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:5c34b25da232ead53a6f335b76dbea124f4d152ad568b9080d6f944bc2b34b52", size = 1289883, upload-time = "2026-05-18T17:05:36.019Z" },
+    { url = "https://files.pythonhosted.org/packages/94/51/f975cae76d44274cc2868dc9040ac5d58d464784610234455b4e7b19c6ef/black-26.5.1-py3-none-any.whl", hash = "sha256:4ed7f7da04046d2e488437170797d3b4a4ad83906683bcb7dfc68b673bbce5e2", size = 213693, upload-time = "2026-05-18T16:53:33.964Z" },
 ]
 
 [[package]]
@@ -625,47 +636,45 @@ wheels = [
 
 [[package]]
 name = "cryptography"
-version = "46.0.6"
+version = "50.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a4/ba/04b1bd4218cbc58dc90ce967106d51582371b898690f3ae0402876cc4f34/cryptography-46.0.6.tar.gz", hash = "sha256:27550628a518c5c6c903d84f637fbecf287f6cb9ced3804838a1295dc1fd0759", size = 750542, upload-time = "2026-03-25T23:34:53.396Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ad/5d6702db60b1e40b41ef513b6967ff5848f307d50f8449baf1634f5908f1/cryptography-50.0.1.tar.gz", hash = "sha256:5dd9bda1c12b4162f6ff568eeb5e0ff956c28d14406e875cfe8a63a2d414ff20", size = 880381, upload-time = "2026-08-25T19:45:45.499Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/23/9285e15e3bc57325b0a72e592921983a701efc1ee8f91c06c5f0235d86d9/cryptography-46.0.6-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:64235194bad039a10bb6d2d930ab3323baaec67e2ce36215fd0952fad0930ca8", size = 7176401, upload-time = "2026-03-25T23:33:22.096Z" },
-    { url = "https://files.pythonhosted.org/packages/60/f8/e61f8f13950ab6195b31913b42d39f0f9afc7d93f76710f299b5ec286ae6/cryptography-46.0.6-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:26031f1e5ca62fcb9d1fcb34b2b60b390d1aacaa15dc8b895a9ed00968b97b30", size = 4275275, upload-time = "2026-03-25T23:33:23.844Z" },
-    { url = "https://files.pythonhosted.org/packages/19/69/732a736d12c2631e140be2348b4ad3d226302df63ef64d30dfdb8db7ad1c/cryptography-46.0.6-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9a693028b9cbe51b5a1136232ee8f2bc242e4e19d456ded3fa7c86e43c713b4a", size = 4425320, upload-time = "2026-03-25T23:33:25.703Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/12/123be7292674abf76b21ac1fc0e1af50661f0e5b8f0ec8285faac18eb99e/cryptography-46.0.6-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:67177e8a9f421aa2d3a170c3e56eca4e0128883cf52a071a7cbf53297f18b175", size = 4278082, upload-time = "2026-03-25T23:33:27.423Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/ba/d5e27f8d68c24951b0a484924a84c7cdaed7502bac9f18601cd357f8b1d2/cryptography-46.0.6-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:d9528b535a6c4f8ff37847144b8986a9a143585f0540fbcb1a98115b543aa463", size = 4926514, upload-time = "2026-03-25T23:33:29.206Z" },
-    { url = "https://files.pythonhosted.org/packages/34/71/1ea5a7352ae516d5512d17babe7e1b87d9db5150b21f794b1377eac1edc0/cryptography-46.0.6-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:22259338084d6ae497a19bae5d4c66b7ca1387d3264d1c2c0e72d9e9b6a77b97", size = 4457766, upload-time = "2026-03-25T23:33:30.834Z" },
-    { url = "https://files.pythonhosted.org/packages/01/59/562be1e653accee4fdad92c7a2e88fced26b3fdfce144047519bbebc299e/cryptography-46.0.6-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:760997a4b950ff00d418398ad73fbc91aa2894b5c1db7ccb45b4f68b42a63b3c", size = 3986535, upload-time = "2026-03-25T23:33:33.02Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/8b/b1ebfeb788bf4624d36e45ed2662b8bd43a05ff62157093c1539c1288a18/cryptography-46.0.6-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:3dfa6567f2e9e4c5dceb8ccb5a708158a2a871052fa75c8b78cb0977063f1507", size = 4277618, upload-time = "2026-03-25T23:33:34.567Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/52/a005f8eabdb28df57c20f84c44d397a755782d6ff6d455f05baa2785bd91/cryptography-46.0.6-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:cdcd3edcbc5d55757e5f5f3d330dd00007ae463a7e7aa5bf132d1f22a4b62b19", size = 4890802, upload-time = "2026-03-25T23:33:37.034Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/4d/8e7d7245c79c617d08724e2efa397737715ca0ec830ecb3c91e547302555/cryptography-46.0.6-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:d4e4aadb7fc1f88687f47ca20bb7227981b03afaae69287029da08096853b738", size = 4457425, upload-time = "2026-03-25T23:33:38.904Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/5c/f6c3596a1430cec6f949085f0e1a970638d76f81c3ea56d93d564d04c340/cryptography-46.0.6-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2b417edbe8877cda9022dde3a008e2deb50be9c407eef034aeeb3a8b11d9db3c", size = 4405530, upload-time = "2026-03-25T23:33:40.842Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/c9/9f9cea13ee2dbde070424e0c4f621c091a91ffcc504ffea5e74f0e1daeff/cryptography-46.0.6-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:380343e0653b1c9d7e1f55b52aaa2dbb2fdf2730088d48c43ca1c7c0abb7cc2f", size = 4667896, upload-time = "2026-03-25T23:33:42.781Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/b5/1895bc0821226f129bc74d00eccfc6a5969e2028f8617c09790bf89c185e/cryptography-46.0.6-cp311-abi3-win32.whl", hash = "sha256:bcb87663e1f7b075e48c3be3ecb5f0b46c8fc50b50a97cf264e7f60242dca3f2", size = 3026348, upload-time = "2026-03-25T23:33:45.021Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/f8/c9bcbf0d3e6ad288b9d9aa0b1dee04b063d19e8c4f871855a03ab3a297ab/cryptography-46.0.6-cp311-abi3-win_amd64.whl", hash = "sha256:6739d56300662c468fddb0e5e291f9b4d084bead381667b9e654c7dd81705124", size = 3483896, upload-time = "2026-03-25T23:33:46.649Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/cc/f330e982852403da79008552de9906804568ae9230da8432f7496ce02b71/cryptography-46.0.6-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:12cae594e9473bca1a7aceb90536060643128bb274fcea0fc459ab90f7d1ae7a", size = 7162776, upload-time = "2026-03-25T23:34:13.308Z" },
-    { url = "https://files.pythonhosted.org/packages/49/b3/dc27efd8dcc4bff583b3f01d4a3943cd8b5821777a58b3a6a5f054d61b79/cryptography-46.0.6-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:639301950939d844a9e1c4464d7e07f902fe9a7f6b215bb0d4f28584729935d8", size = 4270529, upload-time = "2026-03-25T23:34:15.019Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/05/e8d0e6eb4f0d83365b3cb0e00eb3c484f7348db0266652ccd84632a3d58d/cryptography-46.0.6-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ed3775295fb91f70b4027aeba878d79b3e55c0b3e97eaa4de71f8f23a9f2eb77", size = 4414827, upload-time = "2026-03-25T23:34:16.604Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/97/daba0f5d2dc6d855e2dcb70733c812558a7977a55dd4a6722756628c44d1/cryptography-46.0.6-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8927ccfbe967c7df312ade694f987e7e9e22b2425976ddbf28271d7e58845290", size = 4271265, upload-time = "2026-03-25T23:34:18.586Z" },
-    { url = "https://files.pythonhosted.org/packages/89/06/fe1fce39a37ac452e58d04b43b0855261dac320a2ebf8f5260dd55b201a9/cryptography-46.0.6-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:b12c6b1e1651e42ab5de8b1e00dc3b6354fdfd778e7fa60541ddacc27cd21410", size = 4916800, upload-time = "2026-03-25T23:34:20.561Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/8a/b14f3101fe9c3592603339eb5d94046c3ce5f7fc76d6512a2d40efd9724e/cryptography-46.0.6-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:063b67749f338ca9c5a0b7fe438a52c25f9526b851e24e6c9310e7195aad3b4d", size = 4448771, upload-time = "2026-03-25T23:34:22.406Z" },
-    { url = "https://files.pythonhosted.org/packages/01/b3/0796998056a66d1973fd52ee89dc1bb3b6581960a91ad4ac705f182d398f/cryptography-46.0.6-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:02fad249cb0e090b574e30b276a3da6a149e04ee2f049725b1f69e7b8351ec70", size = 3978333, upload-time = "2026-03-25T23:34:24.281Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/3d/db200af5a4ffd08918cd55c08399dc6c9c50b0bc72c00a3246e099d3a849/cryptography-46.0.6-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e6142674f2a9291463e5e150090b95a8519b2fb6e6aaec8917dd8d094ce750d", size = 4271069, upload-time = "2026-03-25T23:34:25.895Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/18/61acfd5b414309d74ee838be321c636fe71815436f53c9f0334bf19064fa/cryptography-46.0.6-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:456b3215172aeefb9284550b162801d62f5f264a081049a3e94307fe20792cfa", size = 4878358, upload-time = "2026-03-25T23:34:27.67Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/65/5bf43286d566f8171917cae23ac6add941654ccf085d739195a4eacf1674/cryptography-46.0.6-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:341359d6c9e68834e204ceaf25936dffeafea3829ab80e9503860dcc4f4dac58", size = 4448061, upload-time = "2026-03-25T23:34:29.375Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/25/7e49c0fa7205cf3597e525d156a6bce5b5c9de1fd7e8cb01120e459f205a/cryptography-46.0.6-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9a9c42a2723999a710445bc0d974e345c32adfd8d2fac6d8a251fa829ad31cfb", size = 4399103, upload-time = "2026-03-25T23:34:32.036Z" },
-    { url = "https://files.pythonhosted.org/packages/44/46/466269e833f1c4718d6cd496ffe20c56c9c8d013486ff66b4f69c302a68d/cryptography-46.0.6-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6617f67b1606dfd9fe4dbfa354a9508d4a6d37afe30306fe6c101b7ce3274b72", size = 4659255, upload-time = "2026-03-25T23:34:33.679Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/09/ddc5f630cc32287d2c953fc5d32705e63ec73e37308e5120955316f53827/cryptography-46.0.6-cp38-abi3-win32.whl", hash = "sha256:7f6690b6c55e9c5332c0b59b9c8a3fb232ebf059094c17f9019a51e9827df91c", size = 3010660, upload-time = "2026-03-25T23:34:35.418Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/82/ca4893968aeb2709aacfb57a30dec6fa2ab25b10fa9f064b8882ce33f599/cryptography-46.0.6-cp38-abi3-win_amd64.whl", hash = "sha256:79e865c642cfc5c0b3eb12af83c35c5aeff4fa5c672dc28c43721c2c9fdd2f0f", size = 3471160, upload-time = "2026-03-25T23:34:37.191Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/84/7ccff00ced5bac74b775ce0beb7d1be4e8637536b522b5df9b73ada42da2/cryptography-46.0.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:2ea0f37e9a9cf0df2952893ad145fd9627d326a59daec9b0802480fa3bcd2ead", size = 3475444, upload-time = "2026-03-25T23:34:38.944Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/1f/4c926f50df7749f000f20eede0c896769509895e2648db5da0ed55db711d/cryptography-46.0.6-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:a3e84d5ec9ba01f8fd03802b2147ba77f0c8f2617b2aff254cedd551844209c8", size = 4218227, upload-time = "2026-03-25T23:34:40.871Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/65/707be3ffbd5f786028665c3223e86e11c4cda86023adbc56bd72b1b6bab5/cryptography-46.0.6-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:12f0fa16cc247b13c43d56d7b35287ff1569b5b1f4c5e87e92cc4fcc00cd10c0", size = 4381399, upload-time = "2026-03-25T23:34:42.609Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/6d/73557ed0ef7d73d04d9aba745d2c8e95218213687ee5e76b7d236a5030fc/cryptography-46.0.6-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:50575a76e2951fe7dbd1f56d181f8c5ceeeb075e9ff88e7ad997d2f42af06e7b", size = 4217595, upload-time = "2026-03-25T23:34:44.205Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/c5/e1594c4eec66a567c3ac4400008108a415808be2ce13dcb9a9045c92f1a0/cryptography-46.0.6-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:90e5f0a7b3be5f40c3a0a0eafb32c681d8d2c181fc2a1bdabe9b3f611d9f6b1a", size = 4380912, upload-time = "2026-03-25T23:34:46.328Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/89/843b53614b47f97fe1abc13f9a86efa5ec9e275292c457af1d4a60dc80e0/cryptography-46.0.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:6728c49e3b2c180ef26f8e9f0a883a2c585638db64cf265b49c9ba10652d430e", size = 3409955, upload-time = "2026-03-25T23:34:48.465Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/19/797e2aaac9df6a66f1550f49979dc1b1e39ecd2077501c30efa81e8d5d67/cryptography-50.0.1-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:b8f852c65863251b9e3a1b8c150ce21e59b522dbb6a7d4bc80e680d38388e986", size = 4010153, upload-time = "2026-08-25T19:44:03.155Z" },
+    { url = "https://files.pythonhosted.org/packages/90/34/9ce9a62ed9dc82ca9fd6a34445b6904af56e5f38b3eae2ed32e49c36053d/cryptography-50.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:53e279950892dc102c6b4e52af03ae5ea92fac572a1ddab78ca73a997f62b69f", size = 4723133, upload-time = "2026-08-25T19:44:05.461Z" },
+    { url = "https://files.pythonhosted.org/packages/57/26/e6d4fc8512a51a5f9ee7bfdbfb853bce1197087df40c9ad993ad370b846f/cryptography-50.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ff838d62ec1bfce4f9ba7fa16f4a7b554cd8d0c299e6be37502161a660c84eef", size = 4712478, upload-time = "2026-08-25T19:44:07.375Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/de/d3cdc2815697aae84126cbd6a030ca7b6b452e28a88b501b836bd3aa7a86/cryptography-50.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e74591e283fe6eb956416c929eb58262a719fe0311fd9054c62c3350ed8760d8", size = 4730726, upload-time = "2026-08-25T19:44:09.294Z" },
+    { url = "https://files.pythonhosted.org/packages/55/32/38c0d344b98c06d34b5df8946565a9c0d6dbf32c8e0730a7f05f0a3c6cab/cryptography-50.0.1-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:5fe002589592ed749ce77fe0695fcbd3500dd61d7d6db5858a7544c612fa8e45", size = 5353524, upload-time = "2026-08-25T19:44:11.96Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/1b/82f0f0d8858d4432be1af790477edf62aef90324041aa07c57e57bef1af7/cryptography-50.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:51593d180cf6d179bde5c5d065bed81386b1f381656ae7d042b7ffc87a9895ad", size = 4746720, upload-time = "2026-08-25T19:44:14.051Z" },
+    { url = "https://files.pythonhosted.org/packages/29/ba/042ca458b8c64348c768284b5d23e69b92ed53d057ab779fee628564676d/cryptography-50.0.1-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:359e62deae718bce96170e223fdcb6357e4fbd3bb7a3a75f4430763532560e49", size = 4361866, upload-time = "2026-08-25T19:44:16.167Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/e96c1ef71edef71057c7e3c3d982ce8fda554e0c52d0cc19c18845cde3eb/cryptography-50.0.1-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e2ca8fd1b6b4b82a1c4cb02841d0837e3c12336c2e24b520ab8ab3b969733d8f", size = 4730028, upload-time = "2026-08-25T19:44:18.085Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/38/45abd72ef63f2e7d0754a6cacf97bd8b69512ace7f6130d24c39ece65da2/cryptography-50.0.1-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:76de83fbd91ac49c0feaaa983d0748fd7a53176afac5fb3bf7478d244f0eb527", size = 5308405, upload-time = "2026-08-25T19:44:20.197Z" },
+    { url = "https://files.pythonhosted.org/packages/85/66/6ccca4722987ddedaa7fc9c3f4708af7431f5535666c174350830888c6b7/cryptography-50.0.1-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:51afcfceb15597cf2635068e4ac9a56b2abde622edde17f37d85fd7b5306497a", size = 4746230, upload-time = "2026-08-25T19:44:22.376Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0e/b1f92e013228111413f2e6743948b80bc24dfd3c1b87ba98ceea16f5df89/cryptography-50.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:be224a65493ec5b74a158ff22a5522ce4a5ca1e543c647a3a4730d4a09e5f959", size = 4862596, upload-time = "2026-08-25T19:44:24.472Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/22/c3654cccc856e9d682817b04ac3ee79731cb09ca6f95996a95c904de2883/cryptography-50.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9ebcdd5519be9b652a46f507817a74591774fc3d6923ac364e4dfa64e36b291b", size = 5014082, upload-time = "2026-08-25T19:44:26.709Z" },
+    { url = "https://files.pythonhosted.org/packages/42/8b/cb12b1b60c91b074ca6bf0fdd59aa8f10d8bc5f73af8faece86ef0421b37/cryptography-50.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:aed8db4f6d71c51efb89530e12d9464e7bf2923d46c3205dc794a2a93f8c0648", size = 3842826, upload-time = "2026-08-25T19:44:28.784Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a9/ee16a903f13755e914d1eecc482fe64d1f10761c3960e5d8fa6837377aff/cryptography-50.0.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ca83d00d9e69cd5eb63f2e69c3a5a59e0cecae5ae14c6ae0b35830fe3b37bad0", size = 4035307, upload-time = "2026-08-25T19:44:58.305Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/a5/9ec7e81e8526c0d7a387d73386b2daed3f39e10d81a85930bd1b6bfba65c/cryptography-50.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:05ba322c4da95b262a212c345af888ef2c37c88c0509756ea00a0e6d68850f23", size = 4751900, upload-time = "2026-08-25T19:45:00.401Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/3c/0e77bd5ffcf078e9dd27d3074aad6c030d9b10d0bf69329d573c927a188c/cryptography-50.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e22dfed744bd4002e909464cb23d2f0b05c6f3113a79ef2e9864a53db737c733", size = 4738357, upload-time = "2026-08-25T19:45:02.786Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3a/3c5f80daa4dcd47323c7af8a2fcb90de27a33564d4fcac69846c0972691a/cryptography-50.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4c4188f7c0cf655be5c06342b817ed0f9595b69ffa2b12026e5353eed29dea88", size = 4758474, upload-time = "2026-08-25T19:45:04.889Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/2b/214cf0cf93db9628c3c20c896b229f327f6fb1b20e4b3743d8ad3f00af8b/cryptography-50.0.1-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2ebbfb0f1fed745e91796e3e1080a1440423fdae8ece1b995a1d80883a409054", size = 5375862, upload-time = "2026-08-25T19:45:07.163Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/51/3f9701867a46b6c1740c9b52fc4d3bed6cbdcfedcc9b6e64305c07f39cff/cryptography-50.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:407fe2b6db00939c05c0e945e9914238f2f0a430974839429dafc82b1ee6bee5", size = 4772942, upload-time = "2026-08-25T19:45:09.396Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/5c/13ea642e08e2544d0f5396122055f4820cfacb3203562197b5967125ea97/cryptography-50.0.1-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:2b34d76a652ea2b6faf777c35df230c5637842cd904e04f16230c3f9f03e4361", size = 4383347, upload-time = "2026-08-25T19:45:11.659Z" },
+    { url = "https://files.pythonhosted.org/packages/84/d5/7d1fe1cb93f91c428093ff234e128c89ba8ea61a6f26aab406081f9b996e/cryptography-50.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:01f41478cf33fc605a6a089cd56d28b45c6c0b45a1928b61797f2621a04bac71", size = 4758050, upload-time = "2026-08-25T19:45:13.745Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/04/557fc5ead96a829e0bc812a3b9dc4a52a2f27e4f7f5950da7ff27653a805/cryptography-50.0.1-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:fc3ed7ebd2a8c96f5b166de0ab9b624996bef3b07bbeb19364dfb78222c22c80", size = 5332955, upload-time = "2026-08-25T19:45:16.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/eb/5d7124083e8d8cda8f5b348f544b71ad6f707ad63193758ef4d8e569da02/cryptography-50.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9dde0a357190eb3b1da1bb9ab750e9c85cba82ca5977aa0836cbb94e92611239", size = 4772694, upload-time = "2026-08-25T19:45:18.315Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/f1f955e0921dd2b6d22eae7e8d24a4c4b638d10735ffbf6a71f99eb0fcb8/cryptography-50.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd3718b960d0b5dd213cdf03f3bcb7000e69dda0de8b956061947ff6bcff5558", size = 4888413, upload-time = "2026-08-25T19:45:20.4Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ab/89e2b798d2c3925f82e2bb72d5979f3d2f6da2dd22ef4a8cd8b70d920039/cryptography-50.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2a93d05e34d5f67fba6f891fe85d929999baa7195e853923ea6d7576c9e68c5e", size = 5044355, upload-time = "2026-08-25T19:45:22.353Z" },
+    { url = "https://files.pythonhosted.org/packages/99/89/87ef49ffe383ef4e147d27b7bf2088fb0b54ea409dd87b5a89442e5828a5/cryptography-50.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:55d16b1ef3ee0958d893a977b19777887e546c9954ea81b200c3301a864013f2", size = 3875429, upload-time = "2026-08-25T19:45:24.418Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/27/8d207af749c453ee17ea087340b3f2b4adef75aadd1d277b1b129bdda84e/cryptography-50.0.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:9cb3cb952cf5a8abd50c782a98a89d71699715e802fe349704b47f2425b42a94", size = 3974350, upload-time = "2026-08-25T19:45:26.551Z" },
+    { url = "https://files.pythonhosted.org/packages/14/9a/6d3a4d7852e22d657438b7bf51f66102c7d71c0e1fafeec652281d0403e5/cryptography-50.0.1-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:5fe939deeb161024a6be98229c953b6591fef1f41214497a78fe793a244c017f", size = 4698675, upload-time = "2026-08-25T19:45:28.658Z" },
+    { url = "https://files.pythonhosted.org/packages/73/35/5c3717edf9e68a0550ce04e28eab493fe545eccd81742af03f6a75fe260b/cryptography-50.0.1-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:fb4b9672d389c738b175c4166e78310f8a70358886aacd9173ee03a85ffdc671", size = 4707410, upload-time = "2026-08-25T19:45:30.816Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/e0/e786934472e3ac4ecdecc7b129a0ca1a2a40dffdafcf2c3ea9d4397f8def/cryptography-50.0.1-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:d63ae8f6481fec907ac0f588eee8a90aefde112c633131fe540e5711ddbb5a4e", size = 4698378, upload-time = "2026-08-25T19:45:33.043Z" },
+    { url = "https://files.pythonhosted.org/packages/51/cf/5b3f53a0b74d122f023476ede40ba5d3e70d5cf475f73b899740d26a4fb2/cryptography-50.0.1-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:804728ce710890870f3aaa344b2e161172d258d768ac139d02cfd9092d0d94e6", size = 4706889, upload-time = "2026-08-25T19:45:35.086Z" },
+    { url = "https://files.pythonhosted.org/packages/71/44/711e61f7d014be825ef79b285b047292d1bf893732ac1bc030a351fb517f/cryptography-50.0.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:693c99b49bd37d0d096e4334c10232c77248c415b98d35236094cdf96d57258b", size = 3824006, upload-time = "2026-08-25T19:45:37.281Z" },
 ]
 
 [[package]]
@@ -688,6 +697,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/fa/6d96a0978d19e17b68d634497769987b16c8f4cd0a7a05048bec693caa6b/decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360", size = 56711, upload-time = "2025-02-24T04:41:34.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a", size = 9190, upload-time = "2025-02-24T04:41:32.565Z" },
+]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
 ]
 
 [[package]]
@@ -1310,18 +1328,6 @@ wheels = [
 ]
 
 [[package]]
-name = "lia-web"
-version = "0.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cross-web" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/05/3d/7d574a7a5cf5fbc5fc09c07ea3696dd400353b7702bc009cf596b8c12035/lia_web-0.3.1.tar.gz", hash = "sha256:7f551269eddd729f1437e9341ad21622a849eb0c0975d9232ccbbaadbdc74c06", size = 2021, upload-time = "2025-12-25T20:41:51.195Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/8b/b628fc18658f94b3d094708a18b71083cf47628e85cbc6b9edba54d5b2d7/lia_web-0.3.1-py3-none-any.whl", hash = "sha256:e4e6e7a9381e228aca60a6f3d67dbae9a5f4638eced242d931f95797ddba3f8b", size = 5933, upload-time = "2025-12-25T20:41:52.289Z" },
-]
-
-[[package]]
 name = "librt"
 version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1556,14 +1562,14 @@ wheels = [
 
 [[package]]
 name = "mako"
-version = "1.3.10"
+version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/12/b5fa2353e2754cd67fb9f83793fa48ff42c213a5da7e719869d2301f6ab8/mako-1.4.1.tar.gz", hash = "sha256:d7904710b662996425a21627710c4777c45053146942cf8a7aebf757c92b8c27", size = 410165, upload-time = "2026-08-05T06:10:56.611Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/54/12ed58d458474aaab5c3d180173e745a4fe131bb330370596876d19ff60f/mako-1.4.1-py3-none-any.whl", hash = "sha256:a359d9a94a541213958742b2698d0a7757bb83551767bc468a74b9905aba9617", size = 80010, upload-time = "2026-08-05T06:10:58.248Z" },
 ]
 
 [[package]]
@@ -1644,7 +1650,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.0"
+version = "1.29.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1662,9 +1668,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/48/0bb26fdfe7ac16875f534a101ce2405eae192bdef37e7451f2f4507c13ec/mcp-1.29.1.tar.gz", hash = "sha256:1967ba4c315f7a375146209949f45950d18b0efd2f913d7cf3400bc723ee5f04", size = 646823, upload-time = "2026-08-24T18:30:41.161Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/04/d6b4fb82eefe9e81807aabca1ac98f460ae0883974b83a997aaa20c52545/mcp-1.29.1-py3-none-any.whl", hash = "sha256:b6310eeb59153300c4ab8b9aec4c52f4819a2d6a8e429eb43d908bed7c783648", size = 224653, upload-time = "2026-08-24T18:30:39.573Z" },
 ]
 
 [[package]]
@@ -1742,10 +1748,10 @@ dev = [
 requires-dist = [
     { name = "aiofiles", specifier = ">=25.1.0" },
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.67.0" },
-    { name = "arize-phoenix", specifier = ">=12.3.0" },
+    { name = "arize-phoenix", specifier = ">=14.4.0" },
     { name = "async-adbutils" },
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.8.6" },
-    { name = "black", marker = "extra == 'dev'", specifier = "==25.9.0" },
+    { name = "black", marker = "extra == 'dev'", specifier = "==26.5.1" },
     { name = "filelock", specifier = ">=3.20.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "inquirerpy", specifier = ">=0.3.4" },
@@ -1760,7 +1766,7 @@ requires-dist = [
     { name = "llama-index-llms-openai-like", specifier = "==0.7.2" },
     { name = "llama-index-llms-openrouter", specifier = ">=0.4.2" },
     { name = "llama-index-workflows", specifier = ">=2.16.0,<3.0.0" },
-    { name = "mcp", specifier = ">=1.26.0" },
+    { name = "mcp", specifier = ">=1.28.1,<2.0.0" },
     { name = "mobilerun", extras = ["langfuse"], marker = "extra == 'dev'" },
     { name = "mobilerun-core-local", extras = ["cloud"], specifier = ">=0.6.0" },
     { name = "mobilerun-sdk", specifier = ">=3.2.0" },
@@ -1768,7 +1774,7 @@ requires-dist = [
     { name = "openinference-instrumentation-llama-index", marker = "extra == 'langfuse'", specifier = ">=3.0.0" },
     { name = "posthog", specifier = ">=6.7.6" },
     { name = "pydantic", specifier = ">=2.11.10" },
-    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.10.0" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.13.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "rich", specifier = ">=14.1.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.13.0" },
@@ -1779,7 +1785,7 @@ provides-extras = ["anthropic", "dev", "langfuse"]
 [package.metadata.requires-dev]
 dev = [
     { name = "anthropic", specifier = ">=0.67.0" },
-    { name = "arize-phoenix", specifier = ">=11.32.1" },
+    { name = "arize-phoenix", specifier = ">=14.4.0" },
     { name = "bandit", specifier = ">=1.8.6" },
     { name = "llama-index-callbacks-arize-phoenix", specifier = ">=0.6.1" },
     { name = "llama-index-llms-anthropic", specifier = ">=0.8.6,<0.9.0" },
@@ -1971,17 +1977,18 @@ wheels = [
 
 [[package]]
 name = "nltk"
-version = "3.9.4"
+version = "3.10.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
+    { name = "defusedxml" },
     { name = "joblib" },
     { name = "regex" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/a1/b3b4adf15585a5bc4c357adde150c01ebeeb642173ded4d871e89468767c/nltk-3.9.4.tar.gz", hash = "sha256:ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0", size = 2946864, upload-time = "2026-03-24T06:13:40.641Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/e6/fe51d2bb1a3b446f59c5c8165999a9fee208bc346af90a7cbf7657bc0d75/nltk-3.10.3.tar.gz", hash = "sha256:bb9327a461c3811c2fa4900e03840401f2126adfb30c0072827c433bd2444ea4", size = 5137152, upload-time = "2026-08-12T23:46:37.258Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/91/04e965f8e717ba0ab4bdca5c112deeab11c9e750d94c4d4602f050295d39/nltk-3.9.4-py3-none-any.whl", hash = "sha256:f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f", size = 1552087, upload-time = "2026-03-24T06:13:38.47Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6d/ebd2af4640b12168fdf0cb74b6118df2f32a2f62ec7e0c06fbfd80706639/nltk-3.10.3-py3-none-any.whl", hash = "sha256:ff9598a8e20518ee0d557745890cc4435b9578489e2dcbc69c4f81fa060caf7c", size = 1798643, upload-time = "2026-08-12T23:44:13.478Z" },
 ]
 
 [[package]]
@@ -2385,64 +2392,45 @@ wheels = [
 
 [[package]]
 name = "pillow"
-version = "12.2.0"
+version = "12.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/3d/bb7fca845737cf9d7dbde16ed1843984665ff2e0a518f5db43e77ec540b9/pillow-12.3.0.tar.gz", hash = "sha256:3b8182a766685eaa002637e28b4ec8d6b18819a0c71f579bf0dbaa5830297cce", size = 47025035, upload-time = "2026-07-01T11:56:38.965Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/e1/748f5663efe6edcfc4e74b2b93edfb9b8b99b67f21a854c3ae416500a2d9/pillow-12.2.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:8be29e59487a79f173507c30ddf57e733a357f67881430449bb32614075a40ab", size = 5354347, upload-time = "2026-04-01T14:42:44.255Z" },
-    { url = "https://files.pythonhosted.org/packages/47/a1/d5ff69e747374c33a3b53b9f98cca7889fce1fd03d79cdc4e1bccc6c5a87/pillow-12.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:71cde9a1e1551df7d34a25462fc60325e8a11a82cc2e2f54578e5e9a1e153d65", size = 4695873, upload-time = "2026-04-01T14:42:46.452Z" },
-    { url = "https://files.pythonhosted.org/packages/df/21/e3fbdf54408a973c7f7f89a23b2cb97a7ef30c61ab4142af31eee6aebc88/pillow-12.2.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f490f9368b6fc026f021db16d7ec2fbf7d89e2edb42e8ec09d2c60505f5729c7", size = 6280168, upload-time = "2026-04-01T14:42:49.228Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/f1/00b7278c7dd52b17ad4329153748f87b6756ec195ff786c2bdf12518337d/pillow-12.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8bd7903a5f2a4545f6fd5935c90058b89d30045568985a71c79f5fd6edf9b91e", size = 8088188, upload-time = "2026-04-01T14:42:51.735Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/cf/220a5994ef1b10e70e85748b75649d77d506499352be135a4989c957b701/pillow-12.2.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3997232e10d2920a68d25191392e3a4487d8183039e1c74c2297f00ed1c50705", size = 6394401, upload-time = "2026-04-01T14:42:54.343Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/bd/e51a61b1054f09437acfbc2ff9106c30d1eb76bc1453d428399946781253/pillow-12.2.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e74473c875d78b8e9d5da2a70f7099549f9eb37ded4e2f6a463e60125bccd176", size = 7079655, upload-time = "2026-04-01T14:42:56.954Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/3d/45132c57d5fb4b5744567c3817026480ac7fc3ce5d4c47902bc0e7f6f853/pillow-12.2.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:56a3f9c60a13133a98ecff6197af34d7824de9b7b38c3654861a725c970c197b", size = 6503105, upload-time = "2026-04-01T14:42:59.847Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/2e/9df2fc1e82097b1df3dce58dc43286aa01068e918c07574711fcc53e6fb4/pillow-12.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:90e6f81de50ad6b534cab6e5aef77ff6e37722b2f5d908686f4a5c9eba17a909", size = 7203402, upload-time = "2026-04-01T14:43:02.664Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/2e/2941e42858ebb67e50ae741473de81c2984e6eff7b397017623c676e2e8d/pillow-12.2.0-cp311-cp311-win32.whl", hash = "sha256:8c984051042858021a54926eb597d6ee3012393ce9c181814115df4c60b9a808", size = 6378149, upload-time = "2026-04-01T14:43:05.274Z" },
-    { url = "https://files.pythonhosted.org/packages/69/42/836b6f3cd7f3e5fa10a1f1a5420447c17966044c8fbf589cc0452d5502db/pillow-12.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:6e6b2a0c538fc200b38ff9eb6628228b77908c319a005815f2dde585a0664b60", size = 7082626, upload-time = "2026-04-01T14:43:08.557Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/88/549194b5d6f1f494b485e493edc6693c0a16f4ada488e5bd974ed1f42fad/pillow-12.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:9a8a34cc89c67a65ea7437ce257cea81a9dad65b29805f3ecee8c8fe8ff25ffe", size = 2463531, upload-time = "2026-04-01T14:43:10.743Z" },
-    { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421", size = 4695490, upload-time = "2026-04-01T14:43:15.584Z" },
-    { url = "https://files.pythonhosted.org/packages/de/af/4e8e6869cbed569d43c416fad3dc4ecb944cb5d9492defaed89ddd6fe871/pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987", size = 6284462, upload-time = "2026-04-01T14:43:18.268Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76", size = 8094744, upload-time = "2026-04-01T14:43:20.716Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/54/1789c455ed10176066b6e7e6da1b01e50e36f94ba584dc68d9eebfe9156d/pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005", size = 6398371, upload-time = "2026-04-01T14:43:23.443Z" },
-    { url = "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780", size = 7087215, upload-time = "2026-04-01T14:43:26.758Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/f8/2f6825e441d5b1959d2ca5adec984210f1ec086435b0ed5f52c19b3b8a6e/pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5", size = 6509783, upload-time = "2026-04-01T14:43:29.56Z" },
-    { url = "https://files.pythonhosted.org/packages/67/f9/029a27095ad20f854f9dba026b3ea6428548316e057e6fc3545409e86651/pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5", size = 7212112, upload-time = "2026-04-01T14:43:32.091Z" },
-    { url = "https://files.pythonhosted.org/packages/be/42/025cfe05d1be22dbfdb4f264fe9de1ccda83f66e4fc3aac94748e784af04/pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940", size = 6378489, upload-time = "2026-04-01T14:43:34.601Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129, upload-time = "2026-04-01T14:43:37.213Z" },
-    { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612, upload-time = "2026-04-01T14:43:39.421Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/01/53d10cf0dbad820a8db274d259a37ba50b88b24768ddccec07355382d5ad/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c", size = 4100837, upload-time = "2026-04-01T14:43:41.506Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/98/f3a6657ecb698c937f6c76ee564882945f29b79bad496abcba0e84659ec5/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2", size = 4176528, upload-time = "2026-04-01T14:43:43.773Z" },
-    { url = "https://files.pythonhosted.org/packages/69/bc/8986948f05e3ea490b8442ea1c1d4d990b24a7e43d8a51b2c7d8b1dced36/pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c", size = 3640401, upload-time = "2026-04-01T14:43:45.87Z" },
-    { url = "https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795", size = 5308094, upload-time = "2026-04-01T14:43:48.438Z" },
-    { url = "https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f", size = 4695402, upload-time = "2026-04-01T14:43:51.292Z" },
-    { url = "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed", size = 6280005, upload-time = "2026-04-01T14:43:54.242Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9", size = 8090669, upload-time = "2026-04-01T14:43:57.335Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed", size = 6395194, upload-time = "2026-04-01T14:43:59.864Z" },
-    { url = "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3", size = 7082423, upload-time = "2026-04-01T14:44:02.74Z" },
-    { url = "https://files.pythonhosted.org/packages/78/5f/e9f86ab0146464e8c133fe85df987ed9e77e08b29d8d35f9f9f4d6f917ba/pillow-12.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00a2865911330191c0b818c59103b58a5e697cae67042366970a6b6f1b20b7f9", size = 6505667, upload-time = "2026-04-01T14:44:05.381Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/1e/409007f56a2fdce61584fd3acbc2bbc259857d555196cedcadc68c015c82/pillow-12.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e1757442ed87f4912397c6d35a0db6a7b52592156014706f17658ff58bbf795", size = 7208580, upload-time = "2026-04-01T14:44:08.39Z" },
-    { url = "https://files.pythonhosted.org/packages/23/c4/7349421080b12fb35414607b8871e9534546c128a11965fd4a7002ccfbee/pillow-12.2.0-cp313-cp313-win32.whl", hash = "sha256:144748b3af2d1b358d41286056d0003f47cb339b8c43a9ea42f5fea4d8c66b6e", size = 6375896, upload-time = "2026-04-01T14:44:11.197Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/82/8a3739a5e470b3c6cbb1d21d315800d8e16bff503d1f16b03a4ec3212786/pillow-12.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:390ede346628ccc626e5730107cde16c42d3836b89662a115a921f28440e6a3b", size = 7081266, upload-time = "2026-04-01T14:44:13.947Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/25/f968f618a062574294592f668218f8af564830ccebdd1fa6200f598e65c5/pillow-12.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:8023abc91fba39036dbce14a7d6535632f99c0b857807cbbbf21ecc9f4717f06", size = 2463508, upload-time = "2026-04-01T14:44:16.312Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/a4/b342930964e3cb4dce5038ae34b0eab4653334995336cd486c5a8c25a00c/pillow-12.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:042db20a421b9bafecc4b84a8b6e444686bd9d836c7fd24542db3e7df7baad9b", size = 5309927, upload-time = "2026-04-01T14:44:18.89Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/de/23198e0a65a9cf06123f5435a5d95cea62a635697f8f03d134d3f3a96151/pillow-12.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd025009355c926a84a612fecf58bb315a3f6814b17ead51a8e48d3823d9087f", size = 4698624, upload-time = "2026-04-01T14:44:21.115Z" },
-    { url = "https://files.pythonhosted.org/packages/01/a6/1265e977f17d93ea37aa28aa81bad4fa597933879fac2520d24e021c8da3/pillow-12.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88ddbc66737e277852913bd1e07c150cc7bb124539f94c4e2df5344494e0a612", size = 6321252, upload-time = "2026-04-01T14:44:23.663Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/83/5982eb4a285967baa70340320be9f88e57665a387e3a53a7f0db8231a0cd/pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d362d1878f00c142b7e1a16e6e5e780f02be8195123f164edf7eddd911eefe7c", size = 8126550, upload-time = "2026-04-01T14:44:26.772Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/48/6ffc514adce69f6050d0753b1a18fd920fce8cac87620d5a31231b04bfc5/pillow-12.2.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c727a6d53cb0018aadd8018c2b938376af27914a68a492f59dfcaca650d5eea", size = 6433114, upload-time = "2026-04-01T14:44:29.615Z" },
-    { url = "https://files.pythonhosted.org/packages/36/a3/f9a77144231fb8d40ee27107b4463e205fa4677e2ca2548e14da5cf18dce/pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4", size = 7115667, upload-time = "2026-04-01T14:44:32.773Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/fc/ac4ee3041e7d5a565e1c4fd72a113f03b6394cc72ab7089d27608f8aaccb/pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4", size = 6538966, upload-time = "2026-04-01T14:44:35.252Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/a8/27fb307055087f3668f6d0a8ccb636e7431d56ed0750e07a60547b1e083e/pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea", size = 7238241, upload-time = "2026-04-01T14:44:37.875Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/4b/926ab182c07fccae9fcb120043464e1ff1564775ec8864f21a0ebce6ac25/pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24", size = 6379592, upload-time = "2026-04-01T14:44:40.336Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/c4/f9e476451a098181b30050cc4c9a3556b64c02cf6497ea421ac047e89e4b/pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98", size = 7085542, upload-time = "2026-04-01T14:44:43.251Z" },
-    { url = "https://files.pythonhosted.org/packages/00/a4/285f12aeacbe2d6dc36c407dfbbe9e96d4a80b0fb710a337f6d2ad978c75/pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453", size = 2465765, upload-time = "2026-04-01T14:44:45.996Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/b7/2437044fb910f499610356d1352e3423753c98e34f915252aafecc64889f/pillow-12.2.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0538bd5e05efec03ae613fd89c4ce0368ecd2ba239cc25b9f9be7ed426b0af1f", size = 5273969, upload-time = "2026-04-01T14:45:55.538Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/f4/8316e31de11b780f4ac08ef3654a75555e624a98db1056ecb2122d008d5a/pillow-12.2.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:394167b21da716608eac917c60aa9b969421b5dcbbe02ae7f013e7b85811c69d", size = 4659674, upload-time = "2026-04-01T14:45:58.093Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/37/664fca7201f8bb2aa1d20e2c3d5564a62e6ae5111741966c8319ca802361/pillow-12.2.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5d04bfa02cc2d23b497d1e90a0f927070043f6cbf303e738300532379a4b4e0f", size = 5288479, upload-time = "2026-04-01T14:46:01.141Z" },
-    { url = "https://files.pythonhosted.org/packages/49/62/5b0ed78fce87346be7a5cfcfaaad91f6a1f98c26f86bdbafa2066c647ef6/pillow-12.2.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0c838a5125cee37e68edec915651521191cef1e6aa336b855f495766e77a366e", size = 7032230, upload-time = "2026-04-01T14:46:03.874Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/28/ec0fc38107fc32536908034e990c47914c57cd7c5a3ece4d8d8f7ffd7e27/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a6c9fa44005fa37a91ebfc95d081e8079757d2e904b27103f4f5fa6f0bf78c0", size = 5355404, upload-time = "2026-04-01T14:46:06.33Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/8b/51b0eddcfa2180d60e41f06bd6d0a62202b20b59c68f5a132e615b75aecf/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25373b66e0dd5905ed63fa3cae13c82fbddf3079f2c8bf15c6fb6a35586324c1", size = 6002215, upload-time = "2026-04-01T14:46:08.83Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/60/5382c03e1970de634027cee8e1b7d39776b778b81812aaf45b694dfe9e28/pillow-12.2.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:bfa9c230d2fe991bed5318a5f119bd6780cda2915cca595393649fc118ab895e", size = 7080946, upload-time = "2026-04-01T14:46:11.734Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c8/0a78b0e02d7ac54bc03e5321c9220da52f0c2ea83b21f7c40e7f3169c502/pillow-12.3.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:00808c5e14ef63ac5161091d242999076604ff74b883423a11e5d7bbb38bf756", size = 5392415, upload-time = "2026-07-01T11:53:47.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/5b/a02d30018abd97ced9f5a6c63d28597694a00d066516b9c1c6de45859fc9/pillow-12.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:37d6d0a00072fd2948eb22bce7e1475f34569d90c87c59f7a2ec59541b77f7a6", size = 4785266, upload-time = "2026-07-01T11:53:49.079Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/98/766667a4be768150a202836acd9fad19c06824ca86c4286d3cf6b274964e/pillow-12.3.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bcb46e2f9feff8d06323983bd83ed00c201fdcab3d74973e7072a889b3979fcd", size = 6263814, upload-time = "2026-07-01T11:53:51.32Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/2d/ede717bc1144f63886c21fd349bb95860b0d1a21149ff16f2bb362b612b6/pillow-12.3.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23d27a3e0307ec2244cc51e7287b919aa68d097504ebe19df4e76a98a3eea5bd", size = 6934408, upload-time = "2026-07-01T11:53:53.487Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/48/9c58b685e69d49c31af6c8eb9012055fab7e665785165c84796e2c73ce72/pillow-12.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4f883547d4b7f0495ebe7056b0cc2aea76094e7a4abc8e933540f3271df27d9c", size = 6337160, upload-time = "2026-07-01T11:53:55.457Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/fa/dc2a5c0ba6df93f67c31d34b808b7ce440b40cdbf96f0b81cde1d1e6fa93/pillow-12.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:236ff70b9312fb68943c703aa842ca6a758abfa45ac187a5e7c1452e96ef72b5", size = 7045172, upload-time = "2026-07-01T11:53:57.736Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a5/444817a4d4c4c2417df00513086ca196f388d8f9ef40c2e4ccd1ad1af54b/pillow-12.3.0-cp311-cp311-win32.whl", hash = "sha256:10e41f0fbf1eec8cfd234b8fe17a4caac7c9d0db4c204d3c173a8f9f6ef3232b", size = 6472232, upload-time = "2026-07-01T11:53:59.767Z" },
+    { url = "https://files.pythonhosted.org/packages/63/c6/4bad1b18d132a50b27e1365e1ab163616f7a5bb56d330f66f9d1d9d4f9d4/pillow-12.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:8e95e1385e4998ae9694eeaa4730ba5457ff61185b3a55e2e7bea0880aef452a", size = 7233653, upload-time = "2026-07-01T11:54:02.066Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/16/00f91ab7760dc842f5aad55217e80fc4a7067a0604535249bc8a2d6d9870/pillow-12.3.0-cp311-cp311-win_arm64.whl", hash = "sha256:ebaea975e03d3141d9d3a507df75c9b3ec90fa9d2ffd07567b3a978d9d790b26", size = 2568195, upload-time = "2026-07-01T11:54:04.622Z" },
+    { url = "https://files.pythonhosted.org/packages/37/bf/fb3ebff8ddcb76aac5a01389251bbbb9519922a9b520d8247c1ca864a25d/pillow-12.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ba09209fbe443b4acccebe845d8a138b89a8f4fbaeedd44953490b5315d5e965", size = 5345969, upload-time = "2026-07-01T11:54:06.397Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/66/9a386a92561f402389a4fc70c18838bf6d35eb5eb5c6850b4b2dc64f5048/pillow-12.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffd0c5368496f41b0944be820fcb7a838aa6e623d250b01acf2643939c3f99d7", size = 4780323, upload-time = "2026-07-01T11:54:09.351Z" },
+    { url = "https://files.pythonhosted.org/packages/25/27/ac8f99618ffd3dde21db0f4d4b1d2ab00c0880595bfd17df103f7f39fd0c/pillow-12.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9c7f76c0673154f044e9d78c8655fb4213f6ca31a836df48b40fe5d187717b9", size = 6266838, upload-time = "2026-07-01T11:54:11.71Z" },
+    { url = "https://files.pythonhosted.org/packages/84/21/a35af28dcc61f37ed850a2d64c65c701321dfbf25085e469d5559360cbbf/pillow-12.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:78cb2c6865a35ab8ff8b75fd122f6033b92a62c82801110e48ddd6c936a45d91", size = 6940830, upload-time = "2026-07-01T11:54:13.732Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/51/8b08617af3ad95e33ce6d7dd2c99ed6c8298f7fb131636303956be022e25/pillow-12.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e491916b378fba47242221bb9ead245211b70d504f495d105d17b14a24b4907c", size = 6344383, upload-time = "2026-07-01T11:54:15.756Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/72/cf78ac9780bb93c28328f408973845a309d4d145041665f734572ced1b52/pillow-12.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0dd2064cbc55aaec028ef5fbb60fa47bb6c3e7918e07ff17935284b227a9d2df", size = 7052934, upload-time = "2026-07-01T11:54:17.721Z" },
+    { url = "https://files.pythonhosted.org/packages/20/20/25e0f4dc178a6bc0696793720055519a0de89e7661dae886992decbd2f81/pillow-12.3.0-cp312-cp312-win32.whl", hash = "sha256:dbce0b29841537a2fa4a214c2bbf14de3587c9680caa9b4e217568472490b28f", size = 6472684, upload-time = "2026-07-01T11:54:19.839Z" },
+    { url = "https://files.pythonhosted.org/packages/45/89/da2f7971a317f83d807fdd4065c0af40208e59e692cc43d315a71a0e96d1/pillow-12.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:a2b55dd6b2a4c4b7d87ffa56bdb33fdc5fdb9a462173861a7bc097f17d91cb09", size = 7227137, upload-time = "2026-07-01T11:54:22.025Z" },
+    { url = "https://files.pythonhosted.org/packages/de/47/4845a0a6c0dbf1db8456bd9fc791f13c5ced7ced20606d08a0aacfd25b49/pillow-12.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:331b624368d4f1d069149002f25f44bc61c8919ce8ddb3c45bdad8f6e2d89510", size = 2568267, upload-time = "2026-07-01T11:54:24.051Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ac/31fb64e1e7efb5a4b50cd3d92049ba89ac6e4d8d3bb6a74e15048ca3353e/pillow-12.3.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:21900ce7ba264168cd50defae43cd75d25c833ad4ad6e73ffc5596d12e25ac89", size = 4161684, upload-time = "2026-07-01T11:54:25.934Z" },
+    { url = "https://files.pythonhosted.org/packages/87/b4/9805e23d2b4d77842b468513841fda254ee42f0289d25088340e4ff46e2d/pillow-12.3.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:4e8c2a84d977f50b9daed6eeaf3baef67d00d5d74d932288f02cb94518ee3ace", size = 4255487, upload-time = "2026-07-01T11:54:27.935Z" },
+    { url = "https://files.pythonhosted.org/packages/df/39/ecf519435a200c693fe053a6ee4d835b41cf963a4dfc2551c4e637cb2a71/pillow-12.3.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:ae26d61dfa7a47befdc7572b521024e8745f3d809bd95ca9505a7bba9ef849ec", size = 3696433, upload-time = "2026-07-01T11:54:29.813Z" },
+    { url = "https://files.pythonhosted.org/packages/42/92/2fc3ffad878ae8dd5469ec1bc8eb83b71f48e13efdf68f02709003982a32/pillow-12.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7a743ff716f746fc19a9557f60dab1600d4613255f8a7aeb3cdde4db7eb15a66", size = 5345889, upload-time = "2026-07-01T11:54:31.97Z" },
+    { url = "https://files.pythonhosted.org/packages/10/76/8803c13605b763d33d156c4678fc77f8443389c0c51c8aef707bb02015f4/pillow-12.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d69141514cc30b774ceea5e3ed3a6635c8d8a96edf664689b890f4089111fb35", size = 4780109, upload-time = "2026-07-01T11:54:34.026Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/01/e18aff37cb0b4aac47ac90f016d347a49aca667ef97f190b06ac2aabc928/pillow-12.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f7401aebd7f581d7f83a439d87d474999317ee099218e5ad25d125290990ba65", size = 6263736, upload-time = "2026-07-01T11:54:36.131Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/62/de5bdd77d935331f4f802edc11e4d82950f642caad6cb2f949837b8560e2/pillow-12.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0847a763afefb695bc912d7c131e7e0632d4edc1d8698f58ddabec8e46b8b6d3", size = 6937129, upload-time = "2026-07-01T11:54:38.216Z" },
+    { url = "https://files.pythonhosted.org/packages/70/4d/105627a13300c5e0df1d174230b32fd1273062c96f7745fd552b945d1e1d/pillow-12.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:571b9fcb07b97ef3a492028fb3d2dc0993ca23a06138b0315286566d29ef718a", size = 6339562, upload-time = "2026-07-01T11:54:40.354Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/1d/f13de01a553988ab895ba1c722e06cf3144d4f57656fd5b81b6d881f1179/pillow-12.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:756c768d0c9c2955feb7a56c37ea24aea2e369f8d36a88da270b6a9f19e62b5e", size = 7049439, upload-time = "2026-07-01T11:54:42.489Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/f9/066794cca041b969964f779ee5fa66a9498bbf34248ac39c5d7954e4198f/pillow-12.3.0-cp313-cp313-win32.whl", hash = "sha256:a876864214e136f0eb367788dbd7df045f4806801518e2cfe9e13229cfe06d8f", size = 6473287, upload-time = "2026-07-01T11:54:44.9Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9b/7a58e61d62be561da3a356fe2384d4059a6345fc130e23ef1c36a5b81d24/pillow-12.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:1cca606cd25738df4ed873d5ad46bbdb3d83b5cbca291f6b4ff13a4df6b0bbe8", size = 7239691, upload-time = "2026-07-01T11:54:47.141Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b0/c4ed4f0ef8f8fa5ee8351537db6650bb8189f7e118842978dd6589065692/pillow-12.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:b629de27fda84b42cde7edef0d85f13b958b47f6e9bbcbba9b673c562a89bd8b", size = 2568185, upload-time = "2026-07-01T11:54:49.137Z" },
+    { url = "https://files.pythonhosted.org/packages/75/18/2e8b40223153ccbc60df07f9e8928dc0c76202aa4e55ae9f53962b6510d6/pillow-12.3.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:b3c777e849237620b022f7f297dd67705f9f5cf1685f09f02e46f93e92725468", size = 5302510, upload-time = "2026-07-01T11:56:25.736Z" },
+    { url = "https://files.pythonhosted.org/packages/46/3e/51fabf59d5ab801ceab709453d3ab6b180083496579549de4c45ced6528a/pillow-12.3.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:b343699e8308bdc51978310e1c959c584e7869cc8c40780058c87da7781a1e94", size = 4736058, upload-time = "2026-07-01T11:56:28.041Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/20/22fe9384b7949e25fb1293bcfc84fb82590ff4ea6b37c95b24d26d793d86/pillow-12.3.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbd139c8447d25dd750ab79ee274cc5e1fe80fc56340ab10b18a195e1b6eca3e", size = 5237776, upload-time = "2026-07-01T11:56:30.263Z" },
+    { url = "https://files.pythonhosted.org/packages/08/14/f6ba68107680ffa74b39985f3f30884e41318fbc4250caa423c79b4788bb/pillow-12.3.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e7e480451b9fa137494bccd3a7d69adbe8ac65a87d97be61e11f1b1050a5bac3", size = 5860358, upload-time = "2026-07-01T11:56:32.68Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0169bc772ec491108b62f644f8ecf1fe5d8ae5ebafde2ee2142210166903/pillow-12.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:04f01d28a6aaff387bf842a13be313df23ba0597a44f1a976c9feb3c6ff4711a", size = 7231786, upload-time = "2026-07-01T11:56:35.046Z" },
 ]
 
 [[package]]
@@ -2654,11 +2642,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]
@@ -2800,11 +2788,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]
@@ -2860,11 +2848,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]
@@ -3460,15 +3448,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969, upload-time = "2026-08-08T18:27:56.196Z" },
 ]
 
 [[package]]
@@ -3482,18 +3470,18 @@ wheels = [
 
 [[package]]
 name = "strawberry-graphql"
-version = "0.287.3"
+version = "0.314.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "cross-web" },
     { name = "graphql-core" },
-    { name = "lia-web" },
     { name = "packaging" },
     { name = "python-dateutil" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/45/5a466ecd7503ad165ed5050e694f3a871b4df085cfaff5c357259bef0ccc/strawberry_graphql-0.287.3.tar.gz", hash = "sha256:c81126cc75102aa32417048f074429d6c5c8d096424aa939fdb8827b8c5f84a9", size = 211998, upload-time = "2025-12-12T11:50:23.266Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/4d/df1240ee4d8fe925d0b6f0eff15cf9947f0345ab44c39eb58355b6026425/strawberry_graphql-0.314.3.tar.gz", hash = "sha256:2a841c35af61e9d5df1e215ca991cfac364c00a05fc192d9f38d0733da163097", size = 222131, upload-time = "2026-04-08T18:04:42.727Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/8e/ffd20e179cc8218465599922660323f453c7b955aca2b909e5b86ba61eb0/strawberry_graphql-0.287.3-py3-none-any.whl", hash = "sha256:2bb1f9b122ef1213f82f01cf27a095eb0776fda78e12af9e60c54de6e543797c", size = 309183, upload-time = "2025-12-12T11:50:20.574Z" },
+    { url = "https://files.pythonhosted.org/packages/be/25/13773a2944cc5975d44db58233b3610ddc88d4be49e6576adf7ed4b62250/strawberry_graphql-0.314.3-py3-none-any.whl", hash = "sha256:4ef4442cea79014487acd7a0d1a2ce55c9d2a42dcd34a307d4c01f2ab477ecfa", size = 324471, upload-time = "2026-04-08T18:04:44.088Z" },
 ]
 
 [[package]]
@@ -3644,11 +3632,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1279,23 +1279,22 @@ wheels = [
 
 [[package]]
 name = "langfuse"
-version = "3.12.1"
+version = "4.15.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backoff" },
     { name = "httpx" },
-    { name = "openai" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
     { name = "packaging" },
     { name = "pydantic" },
-    { name = "requests" },
+    { name = "typing-extensions" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/87/c28a09b696a1b908cf59b201d01e69066aeab804163d8dba055811790ed5/langfuse-3.12.1.tar.gz", hash = "sha256:da3bf4c0469eab4305f88a63cbb5ef89cf7542abbbcc9136a35c1bc708810520", size = 232768, upload-time = "2026-01-27T06:11:24.648Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/51/ed5569bc2dcc8fe767e3b315207a7511ad23d00d811f02bbf0d6f80bf906/langfuse-4.15.1.tar.gz", hash = "sha256:70cb47529a6ba78383c4f2a197eb3d3ab9d39529c9e6b568d392150c1f40dbb9", size = 432353, upload-time = "2026-08-28T07:55:15.894Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/51/a5752417d704831f8c9fc4d7ec070342dee21d781d92e6fe937e60912e61/langfuse-3.12.1-py3-none-any.whl", hash = "sha256:ccf091ed6b6e0d9d4dbc95ad5cbb0f60c4452ce95b18c114ed5896f4546af38f", size = 416999, upload-time = "2026-01-27T06:11:22.657Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/f9/7160bafcfe9797575359a9e77f810cf26f57f55a7c5ceda602fd9e353ddf/langfuse-4.15.1-py3-none-any.whl", hash = "sha256:795760693a62895157b6f5d6c80f1ad524fd12380995f06f82fc3a627b88c8d4", size = 789929, upload-time = "2026-08-28T07:55:14.034Z" },
 ]
 
 [[package]]
@@ -1750,7 +1749,7 @@ requires-dist = [
     { name = "filelock", specifier = ">=3.20.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "inquirerpy", specifier = ">=0.3.4" },
-    { name = "langfuse", marker = "extra == 'langfuse'", specifier = "==3.12.1" },
+    { name = "langfuse", marker = "extra == 'langfuse'", specifier = "==4.15.1" },
     { name = "llama-index", specifier = "==0.14.23" },
     { name = "llama-index-callbacks-arize-phoenix", specifier = ">=0.6.1" },
     { name = "llama-index-instrumentation", marker = "extra == 'langfuse'" },


### PR DESCRIPTION
## Summary

- migrate Mobilerun tracing from Langfuse 3.12.1 to 4.15.1 using the public Langfuse client, OpenTelemetry preprocessing, and native media handling
- make tracing setup idempotent and concurrency-safe while preserving agent, LLM, screenshot, metadata, user/session, endpoint, and flush behavior
- update the dependency graph to satisfy the patched ranges for all 39 high-severity Dependabot alerts open on `main`
- use Phoenix 14.4.0 because 14.3.0's required prerelease `graphql-core` fails during import

## Dependency refresh

| Package | Locked version |
|---|---:|
| aiohttp | 3.14.3 |
| Arize Phoenix | 14.4.0 |
| Banks | 2.5.0 |
| Black | 26.5.1 |
| cryptography | 50.0.1 |
| Langfuse | 4.15.1 |
| Mako | 1.4.1 |
| MCP | 1.29.1 |
| NLTK | 3.10.3 |
| Pillow | 12.3.0 |
| pyasn1 | 0.6.4 |
| PyJWT | 2.13.0 |
| python-multipart | 0.0.32 |
| Starlette | 1.6.0 |
| Strawberry GraphQL | 0.314.3 |
| urllib3 | 2.7.0 |

The lock remains at 196 packages, adds `defusedxml`, and removes `lia-web`. Every patched threshold for the 39 currently open high alerts is satisfied by this branch; the alerts are expected to close after merge. No medium-only or low-only package was intentionally upgraded.

## Validation

- complete suite: 646 tests and 3 subtests passed
- Ruff and Black 26.5.1 checks passed
- `uv lock --check`, package build, and `git diff --check` passed
- frozen all-extras/all-groups installs and imports passed on Python 3.11 and 3.13
- real MCP 1.29.1 stdio discovery, filtering, invocation, content conversion, and cleanup passed
- Phoenix 14.4.0 started with isolated state; health, OTLP ingestion, and trace retrieval passed
- Android 16 / SDK 36.1 emulator with Portal 0.7.22 completed a bounded Gemini 3.7 Flash agent run in 5 steps
- the local Langfuse-compatible capture received 38 unique spans in one trace: 1 root, 1 agent step, 5 LLM, and 6 screenshot spans; 6 native media uploads completed with no duplicate span IDs, raw screenshot attributes, upload errors, or tracing errors

Fixes #430

Dependency triage: [DRO-2795](https://linear.app/droidrun/issue/DRO-2795/triage-dependabot-alerts-on-droidrunmobilerun)
