### PR TITLE
fix: exclude descendants when finding a clear tap point (#199)

### DIFF
--- a/mobilerun/tools/ui/state.py
+++ b/mobilerun/tools/ui/state.py
@@ -114,9 +114,9 @@ class UIState:
         return info
 
     def get_clear_point(self, index: int) -> Tuple[int, int]:
-        """Find a tap point for *index* that avoids overlapping elements.
+        """Find a tap point for *index* that avoids elements drawn on top of it.
 
-        Falls back to the centre if no clear point exists.
+        Raises ``ValueError`` when the element is genuinely covered.
         """
         element = self._find_by_index(self.elements, index)
         if element is None:
@@ -128,15 +128,25 @@ class UIState:
 
         target_bounds = tuple(map(int, bounds_str.split(",")))
 
+        # Indices are assigned by a pre-order walk of the tree, so every
+        # descendant of the target has a higher index than the target itself.
+        # A descendant is painted *inside* its ancestor rather than over the top
+        # of it, so treating one as a blocker would make any container that its
+        # children happen to fill -- an ordinary list row, say -- untappable.
+        descendants = set(self._collect_indices(element.get("children", [])))
+
         all_elements = self._collect_all(self.elements)
         blockers = []
         for el in all_elements:
             el_idx = el.get("index")
             el_bounds_str = el.get("bounds")
-            if el_idx is not None and el_idx > index and el_bounds_str:
-                el_bounds = tuple(map(int, el_bounds_str.split(",")))
-                if rects_overlap(target_bounds, el_bounds):
-                    blockers.append(el_bounds)
+            if el_idx is None or not el_bounds_str:
+                continue
+            if el_idx <= index or el_idx in descendants:
+                continue
+            el_bounds = tuple(map(int, el_bounds_str.split(",")))
+            if rects_overlap(target_bounds, el_bounds):
+                blockers.append(el_bounds)
 
         point = find_clear_point(target_bounds, blockers)
         if point is None:

--- a/tests/test_clear_point_nesting.py
+++ b/tests/test_clear_point_nesting.py
@@ -1,0 +1,188 @@
+"""Tests for UIState.get_clear_point and its handling of nested elements.
+
+Regression cover for #199. Element indices are assigned by a pre-order walk
+(IndexedFormatter._flatten_with_index), so a descendant always has a higher
+index than its ancestor. get_clear_point treats higher-indexed overlapping
+elements as blockers, which meant a container was blocked by its own children.
+"""
+
+import pytest
+
+from mobilerun.tools.ui.state import UIState
+
+
+def _state(elements):
+    return UIState(
+        elements=elements,
+        formatted_text="",
+        focused_text="",
+        phone_state={},
+        screen_width=1000,
+        screen_height=2000,
+    )
+
+
+def _row_with_children():
+    """A clickable row whose icon + label together cover it completely."""
+    return [
+        {
+            "index": 5,
+            "className": "LinearLayout",
+            "text": "row",
+            "bounds": "0,100,1000,300",
+            "children": [
+                {
+                    "index": 6,
+                    "className": "ImageView",
+                    "text": "icon",
+                    "bounds": "0,100,200,300",
+                    "children": [],
+                },
+                {
+                    "index": 7,
+                    "className": "TextView",
+                    "text": "Settings",
+                    "bounds": "200,100,1000,300",
+                    "children": [],
+                },
+            ],
+        },
+    ]
+
+
+def test_container_is_tappable_despite_being_filled_by_its_children():
+    """#199: a row covered by its own icon and label must still be tappable."""
+    state = _state(_row_with_children())
+    assert state.get_clear_point(5) == (500, 200)
+
+
+def test_container_point_falls_inside_its_own_bounds():
+    state = _state(_row_with_children())
+    x, y = state.get_clear_point(5)
+    assert 0 <= x < 1000
+    assert 100 <= y < 300
+
+
+@pytest.mark.parametrize("index,expected", [(6, (100, 200)), (7, (600, 200))])
+def test_leaf_children_still_resolve_to_their_own_centre(index, expected):
+    state = _state(_row_with_children())
+    assert state.get_clear_point(index) == expected
+
+
+def test_deeply_nested_descendants_are_not_blockers():
+    """Grandchildren are descendants too, not overlays."""
+    elements = [
+        {
+            "index": 1,
+            "className": "FrameLayout",
+            "text": "outer",
+            "bounds": "0,0,1000,400",
+            "children": [
+                {
+                    "index": 2,
+                    "className": "LinearLayout",
+                    "text": "inner",
+                    "bounds": "0,0,1000,400",
+                    "children": [
+                        {
+                            "index": 3,
+                            "className": "TextView",
+                            "text": "label",
+                            "bounds": "0,0,1000,400",
+                            "children": [],
+                        },
+                    ],
+                },
+            ],
+        },
+    ]
+    state = _state(elements)
+    assert state.get_clear_point(1) == (500, 200)
+
+
+def test_later_sibling_overlay_still_blocks():
+    """A real overlay drawn after the target must still be avoided."""
+    elements = [
+        {
+            "index": 1,
+            "className": "LinearLayout",
+            "text": "row",
+            "bounds": "0,0,1000,400",
+            "children": [],
+        },
+        {
+            "index": 2,
+            "className": "FrameLayout",
+            "text": "overlay",
+            # Covers the left half of the row.
+            "bounds": "0,0,500,400",
+            "children": [],
+        },
+    ]
+    state = _state(elements)
+    x, _ = state.get_clear_point(1)
+    assert x >= 500, "tap point should avoid the overlay covering the left half"
+
+
+def test_fully_covering_overlay_still_raises():
+    """A modal covering the target completely is a genuine failure."""
+    elements = [
+        {
+            "index": 1,
+            "className": "LinearLayout",
+            "text": "row",
+            "bounds": "0,0,1000,400",
+            "children": [],
+        },
+        {
+            "index": 2,
+            "className": "FrameLayout",
+            "text": "modal",
+            "bounds": "0,0,1000,400",
+            "children": [],
+        },
+    ]
+    state = _state(elements)
+    with pytest.raises(ValueError, match="fully obscured"):
+        state.get_clear_point(1)
+
+
+def test_overlay_blocks_container_even_when_it_has_children():
+    """Descendants are exempt; a genuine later overlay is not."""
+    elements = _row_with_children() + [
+        {
+            "index": 20,
+            "className": "FrameLayout",
+            "text": "snackbar",
+            "bounds": "0,100,1000,300",
+            "children": [],
+        },
+    ]
+    state = _state(elements)
+    with pytest.raises(ValueError, match="fully obscured"):
+        state.get_clear_point(5)
+
+
+def test_ancestor_never_blocks_its_descendant():
+    """An ancestor is painted behind, and is excluded by the index rule."""
+    state = _state(_row_with_children())
+    # Child 6 sits inside parent 5; the parent must not push the point around.
+    assert state.get_clear_point(6) == (100, 200)
+
+
+def test_missing_index_or_bounds_is_skipped_not_crashed():
+    elements = [
+        {
+            "index": 1,
+            "className": "LinearLayout",
+            "text": "row",
+            "bounds": "0,0,1000,400",
+            "children": [],
+        },
+        # No index.
+        {"className": "View", "text": "ghost", "bounds": "0,0,500,400"},
+        # No bounds.
+        {"index": 3, "className": "View", "text": "boundless", "children": []},
+    ]
+    state = _state(elements)
+    assert state.get_clear_point(1) == (500, 200)


### PR DESCRIPTION
Closes #199.

The report says overlapping elements cause incorrect clicking and that the tree
needs to respect hierarchy. Here's the specific mechanism, and it's a bit worse
than mis-clicking: any container whose children fill it can't be tapped at all.

### Why it happens

`IndexedFormatter._flatten_with_index` assigns indices with a pre-order walk, so
every descendant ends up with a *higher* index than its ancestor.

`UIState.get_clear_point` treats any higher-indexed overlapping element as
something drawn on top of the target:

```python
if el_idx is not None and el_idx > index and el_bounds_str:
    if rects_overlap(target_bounds, el_bounds):
        blockers.append(el_bounds)
```

Descendants satisfy that test. But a descendant is painted inside its ancestor,
not over the top of it, so an element's own children get treated as obstructions
and `find_clear_point` runs out of room.

### Reproduction

An ordinary clickable row with an icon and a label, not a corner case:

```
LinearLayout  index=5  bounds=0,100,1000,300     <- the tappable row
  ImageView   index=6  bounds=0,100,200,300
  TextView    index=7  bounds=200,100,1000,300
```

The two children exactly cover the parent.

Before: `get_clear_point(5)` raises `Element 5 is fully obscured by overlapping elements`
After: `get_clear_point(5)` returns `(500, 200)`, the centre of the row

Tapping the leaf children (6, 7) worked before and still works, which is probably
why this survived. It only bites when the agent targets the container, and the
container is often the only node carrying the click handler.

### The fix

Skip descendants when building the blocker list. That's enough:

* Ancestors are already excluded, since an ancestor always has a lower index.
* Genuine overlays (a snackbar, dialog or FAB drawn after the target) keep their
  higher index and are still treated as blockers.

I also corrected the docstring, which promised a fallback to the centre that the
implementation has never done. It raises instead. Raising seems right for an
element that really is covered, so I assumed the docstring was the wrong half.
Happy to flip it if you'd rather have the documented behaviour.

### Tests

`tests/test_clear_point_nesting.py`, 10 cases: nested children, deeply nested
descendants, a partial overlay the point has to dodge, a full overlay that should
still raise, an overlay over a container that also has children, ancestor
exclusion, and elements missing an index or bounds.

I checked the tests actually catch the bug. Three of them fail against current
`main`, and the seven covering overlay behaviour pass both before and after, so
existing behaviour is unchanged.

Full suite: 653 passed. Four tests fail on my machine
(`test_grok_oauth`, `test_manager_prompt_selection`,
`test_visual_remote_connection`) but they're a pre-existing Windows `cp1252`
decode issue and fail identically on a clean checkout of `main`. `ruff` and
`black` are clean.
