### PR TITLE
fix: honour MOBILERUN_OAUTH_MANUAL across OAuth providers (part of #396)

### DIFF
--- a/docs/sdk/configuration.mdx
+++ b/docs/sdk/configuration.mdx
@@ -639,7 +639,13 @@ export XAI_API_KEY=your-key
 export DEEPSEEK_API_KEY=your-key
 export MINIMAX_API_KEY=your-key
 export MOBILERUN_CONFIG=/path/to/config.yaml  # Custom config path
+export MOBILERUN_OAUTH_MANUAL=true            # Force the manual/headless OAuth login flow
 ```
+
+`MOBILERUN_OAUTH_MANUAL` is detected automatically for SSH, WSL and
+display-less Linux sessions; set it explicitly when you want the copy/paste
+login flow anywhere else. The legacy `DROIDRUN_OAUTH_MANUAL` spelling is still
+honoured.
 
 MiniMax uses `https://api.minimax.io/v1` for global accounts and
 `https://api.minimaxi.com/v1` for Mainland China accounts. The configure wizard

--- a/mobilerun/agent/utils/oauth/anthropic_oauth_llm.py
+++ b/mobilerun/agent/utils/oauth/anthropic_oauth_llm.py
@@ -458,8 +458,10 @@ class AnthropicOAuthLLM(CustomLLM):
         active_deadline.check()
 
         # Headless environments: skip local server, use hosted callback page
-        use_headless = _is_headless_environment() or os.environ.get(
-            "DROIDRUN_OAUTH_MANUAL", ""
+        use_headless = _is_headless_environment() or (
+            os.environ.get("MOBILERUN_OAUTH_MANUAL")
+            or os.environ.get("DROIDRUN_OAUTH_MANUAL")
+            or ""
         ).lower() in ("1", "true", "yes")
         if use_headless:
             return self.login_headless(

--- a/mobilerun/agent/utils/oauth/gemini_oauth_code_assist_llm.py
+++ b/mobilerun/agent/utils/oauth/gemini_oauth_code_assist_llm.py
@@ -548,8 +548,10 @@ class GeminiOAuthCodeAssistLLM(CustomLLM):
         active_deadline.check()
 
         # Headless environments: use authcode redirect flow (no local server)
-        use_authcode = _is_headless_environment() or os.environ.get(
-            "DROIDRUN_OAUTH_MANUAL", ""
+        use_authcode = _is_headless_environment() or (
+            os.environ.get("MOBILERUN_OAUTH_MANUAL")
+            or os.environ.get("DROIDRUN_OAUTH_MANUAL")
+            or ""
         ).lower() in ("1", "true", "yes")
         if use_authcode:
             return self.login_headless(

--- a/mobilerun/agent/utils/oauth/openai_oauth_llm.py
+++ b/mobilerun/agent/utils/oauth/openai_oauth_llm.py
@@ -730,8 +730,10 @@ class OpenAIOAuth(OpenAI):
         _tls_preflight(self._oauth_manager.issuer, deadline=login_deadline)
 
         # Headless environments: use device code flow (no local server needed)
-        use_device_code = _is_headless_environment() or os.environ.get(
-            "DROIDRUN_OAUTH_MANUAL", ""
+        use_device_code = _is_headless_environment() or (
+            os.environ.get("MOBILERUN_OAUTH_MANUAL")
+            or os.environ.get("DROIDRUN_OAUTH_MANUAL")
+            or ""
         ).lower() in ("1", "true", "yes")
         if use_device_code:
             return self._login_device_code(

--- a/mobilerun/telemetry/tracker.py
+++ b/mobilerun/telemetry/tracker.py
@@ -2,7 +2,7 @@
 Anonymous telemetry tracking using PostHog.
 
 This module handles opt-in telemetry collection to help improve Mobilerun.
-All data is anonymized and can be disabled by setting DROIDRUN_TELEMETRY_ENABLED=false.
+All data is anonymized and can be disabled by setting MOBILERUN_TELEMETRY_ENABLED=false.
 """
 
 import asyncio
@@ -24,7 +24,7 @@ USER_ID_PATH = Path.home() / ".droidrun" / "user_id"
 RUN_ID = str(uuid4())
 
 TELEMETRY_ENABLED_MESSAGE = "Anonymized telemetry enabled. See https://docs.mobilerun.ai/v3/guides/telemetry for more information."
-TELEMETRY_DISABLED_MESSAGE = "🛑 Anonymized telemetry disabled. Consider setting the DROIDRUN_TELEMETRY_ENABLED environment variable to 'true' to enable telemetry and help us improve Mobilerun."
+TELEMETRY_DISABLED_MESSAGE = "🛑 Anonymized telemetry disabled. Consider setting the MOBILERUN_TELEMETRY_ENABLED environment variable to 'true' to enable telemetry and help us improve Mobilerun."
 
 # Created lazily on first capture/flush. Constructing the PostHog client spawns
 # a consumer thread and registers a blocking atexit flush, which added ~5s to
@@ -49,7 +49,7 @@ def is_telemetry_enabled():
     Check if telemetry is enabled via environment variable.
 
     Returns:
-        True if DROIDRUN_TELEMETRY_ENABLED is set to true/1/yes/y (case-insensitive),
+        True if MOBILERUN_TELEMETRY_ENABLED is set to true/1/yes/y (case-insensitive),
         or if the environment variable is not set (default is enabled).
     """
     telemetry_enabled = (
@@ -66,7 +66,7 @@ def print_telemetry_message():
     """
     Print telemetry status message to the logger.
 
-    Displays enabled or disabled message based on DROIDRUN_TELEMETRY_ENABLED setting.
+    Displays enabled or disabled message based on MOBILERUN_TELEMETRY_ENABLED setting.
     """
     if is_telemetry_enabled():
         mobilerun_logger.debug(TELEMETRY_ENABLED_MESSAGE)

--- a/tests/test_oauth_manual_env_var.py
+++ b/tests/test_oauth_manual_env_var.py
@@ -1,0 +1,127 @@
+"""Regression tests for the MOBILERUN_OAUTH_MANUAL environment variable.
+
+Every other user-facing env var reads MOBILERUN_* first and falls back to the
+legacy DROIDRUN_* name (see ConfigLoader.load and is_telemetry_enabled).
+OAUTH_MANUAL was the one that never got the MOBILERUN_* spelling, so a user
+following current docs had no way to force the manual/headless login flow.
+
+These tests drive the real ``login()`` branch: ``_is_headless_environment`` is
+forced False so the env var is the only thing that can select the manual path,
+and the manual entry point is stubbed on the class with a sentinel.
+"""
+
+import pytest
+
+from mobilerun.agent.utils.oauth import (
+    anthropic_oauth_llm,
+    gemini_oauth_code_assist_llm,
+    openai_oauth_llm,
+)
+from mobilerun.agent.utils.oauth.anthropic_oauth_llm import AnthropicOAuthLLM
+from mobilerun.agent.utils.oauth.gemini_oauth_code_assist_llm import (
+    GeminiOAuthCodeAssistLLM,
+)
+from mobilerun.agent.utils.oauth.openai_oauth_llm import OpenAIOAuth
+
+SENTINEL = "manual-flow-selected"
+
+# (module, LLM class, manual-flow method, constructor kwargs).
+# The three providers spell their credential-path kwarg differently.
+CASES = (
+    (
+        anthropic_oauth_llm,
+        AnthropicOAuthLLM,
+        "login_headless",
+        {"credential_path": None},
+    ),
+    (
+        gemini_oauth_code_assist_llm,
+        GeminiOAuthCodeAssistLLM,
+        "login_headless",
+        {"credential_path": None},
+    ),
+    (
+        openai_oauth_llm,
+        OpenAIOAuth,
+        "_login_device_code",
+        {"model": "gpt-5.5", "oauth_credential_path": None},
+    ),
+)
+
+CASE_IDS = [cls.__name__ for _, cls, _, _ in CASES]
+
+
+@pytest.fixture(autouse=True)
+def _clear_oauth_env(monkeypatch):
+    monkeypatch.delenv("MOBILERUN_OAUTH_MANUAL", raising=False)
+    monkeypatch.delenv("DROIDRUN_OAUTH_MANUAL", raising=False)
+
+
+def _took_manual_path(monkeypatch, module, cls, manual_method, kwargs) -> bool:
+    """Call the real login() and report whether it delegated to the manual flow."""
+    monkeypatch.setattr(module, "_is_headless_environment", lambda: False)
+
+    # The OpenAI login() reaches the network before the env-var branch.
+    if hasattr(module, "_tls_preflight"):
+        monkeypatch.setattr(module, "_tls_preflight", lambda *a, **kw: None)
+
+    reached = []
+
+    def _stub(self, *args, **kwargs):
+        reached.append(True)
+        return SENTINEL
+
+    monkeypatch.setattr(cls, manual_method, _stub)
+
+    llm = cls(**kwargs)
+    try:
+        llm.login(open_browser=False, timeout_seconds=0.01)
+    except Exception:
+        # The interactive desktop path needs a browser, a local callback server
+        # and real credentials, so it raises here. Whether the manual branch was
+        # taken is recorded above, so this does not mask the result.
+        pass
+    return bool(reached)
+
+
+@pytest.mark.parametrize("module,cls,manual_method,kwargs", CASES, ids=CASE_IDS)
+@pytest.mark.parametrize("value", ("1", "true", "yes", "TRUE", "Yes"))
+def test_mobilerun_oauth_manual_selects_manual_flow(
+    monkeypatch, module, cls, manual_method, kwargs, value
+):
+    monkeypatch.setenv("MOBILERUN_OAUTH_MANUAL", value)
+    assert _took_manual_path(monkeypatch, module, cls, manual_method, kwargs)
+
+
+@pytest.mark.parametrize("module,cls,manual_method,kwargs", CASES, ids=CASE_IDS)
+@pytest.mark.parametrize("value", ("1", "true", "yes"))
+def test_legacy_droidrun_oauth_manual_still_honoured(
+    monkeypatch, module, cls, manual_method, kwargs, value
+):
+    monkeypatch.setenv("DROIDRUN_OAUTH_MANUAL", value)
+    assert _took_manual_path(monkeypatch, module, cls, manual_method, kwargs)
+
+
+@pytest.mark.parametrize("module,cls,manual_method,kwargs", CASES, ids=CASE_IDS)
+def test_mobilerun_takes_precedence_over_legacy(
+    monkeypatch, module, cls, manual_method, kwargs
+):
+    monkeypatch.setenv("MOBILERUN_OAUTH_MANUAL", "true")
+    monkeypatch.setenv("DROIDRUN_OAUTH_MANUAL", "false")
+    assert _took_manual_path(monkeypatch, module, cls, manual_method, kwargs)
+
+
+@pytest.mark.parametrize("module,cls,manual_method,kwargs", CASES, ids=CASE_IDS)
+@pytest.mark.parametrize("value", ("", "0", "false", "no", "off"))
+def test_falsy_values_do_not_select_manual_flow(
+    monkeypatch, module, cls, manual_method, kwargs, value
+):
+    monkeypatch.setenv("MOBILERUN_OAUTH_MANUAL", value)
+    assert not _took_manual_path(monkeypatch, module, cls, manual_method, kwargs)
+
+
+@pytest.mark.parametrize("module,cls,manual_method,kwargs", CASES, ids=CASE_IDS)
+def test_unset_does_not_select_manual_flow(
+    monkeypatch, module, cls, manual_method, kwargs
+):
+    assert not _took_manual_path(monkeypatch, module, cls, manual_method, kwargs)


### PR DESCRIPTION
Part of #396.

While working out what's left of the `droidrun` to `mobilerun` rename I found one
user-facing environment variable that got missed. It's a functional gap rather
than a cosmetic one.

### The gap

The rename gave every user-facing env var a `MOBILERUN_*` spelling, keeping the
legacy `DROIDRUN_*` name as a fallback:

| Variable | `MOBILERUN_*` supported? |
|---|---|
| `MOBILERUN_CONFIG` | yes, with a `DeprecationWarning` for the old name |
| `MOBILERUN_TELEMETRY_ENABLED` | yes |
| `MOBILERUN_STREAM_SCREENSHOTS` | yes, 3 call sites |
| `OAUTH_MANUAL` | no, `DROIDRUN_OAUTH_MANUAL` only |

`OAUTH_MANUAL` is read in all three OAuth login paths and each one only checked
`DROIDRUN_OAUTH_MANUAL`. Anyone setting `MOBILERUN_OAUTH_MANUAL`, which is the
spelling consistent with every other documented variable, silently got the
interactive browser flow instead. On a headless box that
`_is_headless_environment()` doesn't catch, there was no working way to force the
copy/paste login.

### What this changes

* Reads `MOBILERUN_OAUTH_MANUAL` first and falls back to `DROIDRUN_OAUTH_MANUAL`,
  matching the pattern in `ConfigLoader.load` and `is_telemetry_enabled`.
* Documents the variable in `docs/sdk/configuration.mdx`. It wasn't documented
  under either name.
* Fixes the telemetry docstrings and the user-facing "telemetry disabled" message,
  which still told people to set `DROIDRUN_TELEMETRY_ENABLED` even though the code
  prefers `MOBILERUN_TELEMETRY_ENABLED` and the docs already use the new name.

### What I deliberately didn't rename

#396 reads like it could be a repo-wide find and replace, but a mechanical rename
would break existing installs. These `droidrun` references look load-bearing to
me, so I left them alone:

* `compat/droidrun/`, the intentional backwards-compat shim package.
* `~/.droidrun/user_id` and the `"droidrun"` platformdirs app name. That's on-disk
  state, so renaming it orphans every existing user's config file and resets their
  anonymous telemetry id. Feels like it wants a migration step rather than a
  rename.
* The `droidrun.*` OpenTelemetry span and attribute names
  (`droidrun.screenshot`, `droidrun.vision.enabled`, `droidrun_version`), since
  that's wire format already being consumed by existing dashboards.
* `github.com/droidrun/mobilerun` URLs, because the org is still `droidrun`.

Happy to do the on-disk config and telemetry migration as a separate PR if you
want it. It needs a real migration path so it seemed worth keeping out of this
one.

### Tests

`tests/test_oauth_manual_env_var.py`, 45 cases across all three providers: both
spellings, precedence when both are set, and falsy or unset values. I checked they
fail (18 failures) with the source change reverted.

Full suite: 643 passed, with the same 4 pre-existing Windows encoding failures
that occur on a clean `main`. `ruff`, `black` and `bandit` are clean.
