### PR TITLE
feat: add latest Gemini, Claude, and GPT models

### DIFF
--- a/mobilerun/agent/providers/anthropic.py
+++ b/mobilerun/agent/providers/anthropic.py
@@ -7,9 +7,11 @@ from typing import Any
 
 ANTHROPIC_API_DEFAULT_MODEL = "claude-sonnet-4-6"
 ANTHROPIC_OAUTH_DEFAULT_MODEL = "claude-opus-4-7"
+ANTHROPIC_FABLE_5_1_MODEL = "claude-fable-5-1"
 
 ANTHROPIC_API_MODELS = (
     ANTHROPIC_API_DEFAULT_MODEL,
+    ANTHROPIC_FABLE_5_1_MODEL,
     "claude-opus-5",
     "claude-sonnet-5",
     "claude-fable-5",
@@ -20,6 +22,7 @@ ANTHROPIC_API_MODELS = (
 
 ANTHROPIC_OAUTH_MODELS = (
     ANTHROPIC_OAUTH_DEFAULT_MODEL,
+    ANTHROPIC_FABLE_5_1_MODEL,
     "claude-opus-5",
     "claude-sonnet-5",
     "claude-fable-5",
@@ -32,6 +35,7 @@ ANTHROPIC_OAUTH_MODELS = (
 ANTHROPIC_MODEL_CONTEXT_WINDOWS = {
     "claude-opus-5": 1_000_000,
     "claude-sonnet-5": 1_000_000,
+    ANTHROPIC_FABLE_5_1_MODEL: 1_000_000,
     "claude-fable-5": 1_000_000,
     "claude-opus-4-8": 1_000_000,
     "claude-opus-4-7": 1_000_000,
@@ -47,6 +51,7 @@ ANTHROPIC_MODELS_WITHOUT_SAMPLING_PARAMS = frozenset(
     {
         "claude-opus-5",
         "claude-sonnet-5",
+        ANTHROPIC_FABLE_5_1_MODEL,
         "claude-fable-5",
         "claude-opus-4-8",
         "claude-opus-4-7",
@@ -63,6 +68,7 @@ ANTHROPIC_HIGHRES_MODELS = frozenset(
         "claude-opus-4-8",
         "claude-opus-5",
         "claude-sonnet-5",
+        ANTHROPIC_FABLE_5_1_MODEL,
         "claude-fable-5",
         "claude-mythos-5",
     }

--- a/mobilerun/agent/providers/registry.py
+++ b/mobilerun/agent/providers/registry.py
@@ -50,6 +50,10 @@ GEMINI_API_MODELS: tuple[str, ...] = (
     "gemini-3-flash-preview",
     "gemini-3.1-pro-preview",
 )
+_GEMINI_OAUTH_MODEL_DISPLAY_NAMES: dict[str, str] = {
+    "gemini-3.8-flash-tiered": "gemini-3.8-flash",
+    "gemini-3.7-flash-tiered": "gemini-3.7-flash",
+}
 
 
 PROVIDER_FAMILIES: tuple[ProviderFamilySpec, ...] = (
@@ -302,6 +306,16 @@ def list_models_for_variant(
     family_id: str, auth_mode: str | None = None
 ) -> tuple[str, ...]:
     return resolve_provider_variant(family_id, auth_mode).models
+
+
+def model_display_name_for_variant(
+    family_id: str, auth_mode: str | None, model_id: str
+) -> str:
+    """Return a user-facing model name without changing its canonical id."""
+    variant = resolve_provider_variant(family_id, auth_mode)
+    if variant.id == "gemini_oauth_code_assist":
+        return _GEMINI_OAUTH_MODEL_DISPLAY_NAMES.get(model_id, model_id)
+    return model_id
 
 
 def normalize_model_id_for_variant(

--- a/mobilerun/agent/providers/registry.py
+++ b/mobilerun/agent/providers/registry.py
@@ -43,6 +43,7 @@ OPENAI_MODEL_ALIASES: dict[str, str] = {
 GEMINI_API_DEFAULT_MODEL = "gemini-3.7-flash"
 GEMINI_API_MODELS: tuple[str, ...] = (
     GEMINI_API_DEFAULT_MODEL,
+    "gemini-3.8-flash",
     "gemini-3.5-flash",
     "gemini-3.6-flash",
     "gemini-3.5-flash-lite",
@@ -72,6 +73,8 @@ PROVIDER_FAMILIES: tuple[ProviderFamilySpec, ...] = (
                 default_model="gemini-3.5-flash-low",
                 models=(
                     "gemini-3.5-flash-low",
+                    "gemini-3.8-flash-tiered",
+                    "gemini-3.7-flash-tiered",
                     "gemini-3.5-flash-extra-low",
                     "gemini-3-flash-agent",
                     "gemini-3-flash",
@@ -96,6 +99,7 @@ PROVIDER_FAMILIES: tuple[ProviderFamilySpec, ...] = (
                 default_model="gpt-5.5",
                 models=(
                     "gpt-5.5",
+                    "gpt-6-astra",
                     "gpt-5.6-sol",
                     "gpt-5.6-terra",
                     "gpt-5.6-luna",
@@ -112,6 +116,7 @@ PROVIDER_FAMILIES: tuple[ProviderFamilySpec, ...] = (
                 default_model="gpt-5.5",
                 models=(
                     "gpt-5.5",
+                    "gpt-6-astra",
                     "gpt-5.6-sol",
                     "gpt-5.6-terra",
                     "gpt-5.6-luna",

--- a/mobilerun/agent/utils/llm_picker.py
+++ b/mobilerun/agent/utils/llm_picker.py
@@ -1,9 +1,11 @@
 import logging
 from typing import TYPE_CHECKING, Any
 
+from llama_index.core.base.llms.types import LLMMetadata
 from llama_index.core.llms.llm import LLM
 
 from mobilerun.agent.providers.anthropic import (
+    ANTHROPIC_FABLE_5_1_MODEL,
     ANTHROPIC_UNSUPPORTED_SAMPLING_PARAMS,
     anthropic_model_context_window,
     anthropic_model_omits_sampling_params,
@@ -65,6 +67,7 @@ ZAI_GLOBAL_API_BASE = "https://api.z.ai/api/paas/v4"
 # Antigravity OAuth catalog. Catch these locally so users get the applicable
 # OAuth choices instead of a remote model-not-found response.
 GEMINI_OAUTH_UNSUPPORTED_MODELS = {
+    "gemini-3.8-flash",
     "gemini-3.7-flash",
     "gemini-3.6-flash",
     "gemini-3.5-flash-lite",
@@ -74,6 +77,7 @@ GEMINI_OAUTH_UNSUPPORTED_MODELS = {
 }
 OPENAI_OAUTH_UNSUPPORTED_MODELS = {"gpt-5.3-codex"}
 OPENAI_RESPONSES_MODELS_WITHOUT_SAMPLING_PARAMS = {
+    "gpt-6-astra",
     "gpt-5.5",
     "gpt-5.6-sol",
     "gpt-5.6-terra",
@@ -83,7 +87,13 @@ OPENAI_RESPONSES_MODELS_WITHOUT_SAMPLING_PARAMS = {
     "gpt-5.4-nano",
 }
 OPENAI_RESPONSES_UNSUPPORTED_SAMPLING_PARAMS = {"temperature", "top_p"}
+OPENAI_ASTRA_MODEL = "gpt-6-astra"
+OPENAI_ASTRA_CONTEXT_WINDOW = 1_050_000
+OPENAI_ASTRA_UNSUPPORTED_PARAMS = {"logprobs", "top_logprobs"}
+OPENAI_ASTRA_UNSUPPORTED_INCLUDE = "message.output_text.logprobs"
+OPENAI_ASTRA_REASONING_EFFORTS = {"low", "medium", "high", "xhigh", "max"}
 GOOGLE_GENAI_MODELS_WITHOUT_SAMPLING_PARAMS = {
+    "gemini-3.8-flash",
     "gemini-3.7-flash",
     "gemini-3.6-flash",
     "gemini-3.5-flash-lite",
@@ -200,6 +210,54 @@ def _load_openai_responses(*, grok: bool = False, **kwargs: Any) -> LLM:
     from llama_index.llms.openai.utils import to_openai_message_dicts
 
     class MobilerunOpenAIResponses(OpenAIResponses):
+        @staticmethod
+        def _validate_astra_reasoning(reasoning: object) -> None:
+            if reasoning is None:
+                return
+            if not isinstance(reasoning, dict):
+                raise ValueError(
+                    "gpt-6-astra reasoning must be a mapping with an optional "
+                    "'effort' value."
+                )
+            effort = reasoning.get("effort")
+            if effort is None:
+                return
+            if effort not in OPENAI_ASTRA_REASONING_EFFORTS:
+                supported = ", ".join(sorted(OPENAI_ASTRA_REASONING_EFFORTS))
+                raise ValueError(
+                    f"gpt-6-astra does not support reasoning effort {effort!r}; "
+                    f"use one of: {supported}."
+                )
+
+        @classmethod
+        def _sanitize_astra_payload_fields(
+            cls,
+            payload: dict[str, Any],
+            *,
+            drop_model: bool = False,
+        ) -> dict[str, Any]:
+            sanitized = dict(payload)
+            unsupported = (
+                OPENAI_RESPONSES_UNSUPPORTED_SAMPLING_PARAMS
+                | OPENAI_ASTRA_UNSUPPORTED_PARAMS
+            )
+            for param in unsupported:
+                sanitized.pop(param, None)
+
+            include = sanitized.get("include")
+            if isinstance(include, (list, tuple)):
+                filtered_include = [
+                    value
+                    for value in include
+                    if value != OPENAI_ASTRA_UNSUPPORTED_INCLUDE
+                ]
+                sanitized["include"] = filtered_include or None
+
+            cls._validate_astra_reasoning(sanitized.get("reasoning"))
+            if drop_model:
+                sanitized.pop("model", None)
+            return sanitized
+
         def _sanitize_call_kwargs(
             self,
             call_kwargs: dict[str, Any],
@@ -222,15 +280,62 @@ def _load_openai_responses(*, grok: bool = False, **kwargs: Any) -> LLM:
             if _openai_responses_model_omits_sampling_params(effective_model):
                 for param in OPENAI_RESPONSES_UNSUPPORTED_SAMPLING_PARAMS:
                     sanitized.pop(param, None)
+            if (
+                self.model == OPENAI_ASTRA_MODEL
+                or effective_model == OPENAI_ASTRA_MODEL
+            ):
+                sanitized = self._sanitize_astra_payload_fields(sanitized)
+                extra_body = sanitized.get("extra_body")
+                if isinstance(extra_body, dict):
+                    sanitized["extra_body"] = self._sanitize_astra_payload_fields(
+                        extra_body,
+                        drop_model=True,
+                    )
+                if self.model == OPENAI_ASTRA_MODEL:
+                    sanitized["model"] = self.model
             return sanitized
 
         def _get_model_kwargs(self, **kwargs: Any) -> dict[str, Any]:
-            return self._sanitize_call_kwargs(super()._get_model_kwargs(**kwargs))
+            model_kwargs = super()._get_model_kwargs(**kwargs)
+            effective_model = model_kwargs.get("model", self.model)
+            if (
+                (
+                    self.model == OPENAI_ASTRA_MODEL
+                    or effective_model == OPENAI_ASTRA_MODEL
+                )
+                and "reasoning" not in model_kwargs
+                and self.reasoning_options is not None
+            ):
+                model_kwargs["reasoning"] = self.reasoning_options
+            return self._sanitize_call_kwargs(model_kwargs)
+
+        @property
+        def metadata(self) -> LLMMetadata:
+            if self.model != OPENAI_ASTRA_MODEL:
+                return super().metadata
+            return LLMMetadata(
+                context_window=self.context_window or OPENAI_ASTRA_CONTEXT_WINDOW,
+                num_output=self.max_output_tokens or -1,
+                is_chat_model=True,
+                is_function_calling_model=True,
+                model_name=self.model,
+            )
 
         def _sanitize_structured_call_kwargs(
             self, call_kwargs: dict[str, Any]
         ) -> dict[str, Any]:
-            sanitized = self._sanitize_call_kwargs(call_kwargs, omit_tool_choice=grok)
+            merged = dict(call_kwargs)
+            if not grok and self.model == OPENAI_ASTRA_MODEL:
+                configured: dict[str, Any] = {}
+                if self.include is not None:
+                    configured["include"] = self.include
+                if self.reasoning_options is not None:
+                    configured["reasoning"] = self.reasoning_options
+                configured.update(self.additional_kwargs or {})
+                configured.update(merged)
+                merged = configured
+
+            sanitized = self._sanitize_call_kwargs(merged, omit_tool_choice=grok)
             if grok:
                 # The upstream structured adapter passes ``store=self.store``
                 # explicitly. The constructor already pins that field false.
@@ -239,6 +344,11 @@ def _load_openai_responses(*, grok: bool = False, **kwargs: Any) -> LLM:
                 # or a generic caller override to restore it.
                 sanitized.pop("store", None)
                 sanitized.pop("model", None)
+                sanitized.pop("tool_choice", None)
+            elif self.model == OPENAI_ASTRA_MODEL:
+                # The upstream structured adapter supplies these explicitly.
+                sanitized.pop("model", None)
+                sanitized.pop("store", None)
                 sanitized.pop("tool_choice", None)
             return sanitized
 
@@ -453,7 +563,7 @@ def _load_google_genai(**kwargs: Any) -> LLM:
 
 
 def _load_anthropic(**kwargs: Any) -> LLM:
-    from llama_index.core.base.llms.types import LLMMetadata
+    from llama_index.core.types import PydanticProgramMode
     from llama_index.llms.anthropic import Anthropic
 
     class MobilerunAnthropic(Anthropic):
@@ -494,6 +604,12 @@ def _load_anthropic(**kwargs: Any) -> LLM:
     # own loader above and deliberately retains its separate output limit.
     if kwargs.get("max_tokens") is None:
         kwargs["max_tokens"] = 2048
+
+    # Fable 5.1 currently rejects the tool_choice payload produced by the
+    # locked Anthropic adapter for function-based Pydantic programs. Its text
+    # path returns the same validated Pydantic result without that field.
+    if kwargs.get("model") == ANTHROPIC_FABLE_5_1_MODEL:
+        kwargs["pydantic_program_mode"] = PydanticProgramMode.LLM
 
     filtered_kwargs = {k: v for k, v in kwargs.items() if v is not None}
     logger.debug(

--- a/mobilerun/agent/utils/oauth/anthropic_oauth_llm.py
+++ b/mobilerun/agent/utils/oauth/anthropic_oauth_llm.py
@@ -33,6 +33,7 @@ from llama_index.core.llms.callbacks import llm_chat_callback, llm_completion_ca
 from llama_index.core.llms.custom import CustomLLM
 
 from mobilerun.agent.providers.anthropic import (
+    ANTHROPIC_FABLE_5_1_MODEL,
     ANTHROPIC_OAUTH_DEFAULT_MODEL,
     anthropic_model_context_window,
     anthropic_model_omits_sampling_params,
@@ -62,7 +63,11 @@ DEFAULT_SETUP_TOKEN_SCOPE = "user:inference"
 DEFAULT_REFRESH_SCOPE = "user:inference user:profile user:file_upload user:mcp_servers user:sessions:claude_code"
 DEFAULT_OAUTH_BETA = "oauth-2025-04-20"
 DEFAULT_ANTHROPIC_VERSION = "2023-06-01"
-DEFAULT_CC_VERSION = "2.1.85.000"
+# Model access is Claude Code version-gated, so keep the HTTP user agent and
+# billing marker derived from the same verified-compatible client version.
+DEFAULT_CLAUDE_CODE_VERSION = "2.1.259"
+DEFAULT_USER_AGENT = f"claude-cli/{DEFAULT_CLAUDE_CODE_VERSION}"
+DEFAULT_CC_VERSION = f"{DEFAULT_CLAUDE_CODE_VERSION}.000"
 DEFAULT_CC_ENTRYPOINT = "cli"
 _IGNORED_REQUEST_KWARGS = {
     "formatted",
@@ -148,7 +153,7 @@ class AnthropicOAuthLLM(CustomLLM):
     api_base: str = Field(default=DEFAULT_API_BASE)
     anthropic_version: str = Field(default=DEFAULT_ANTHROPIC_VERSION)
     oauth_beta: str = Field(default=DEFAULT_OAUTH_BETA)
-    user_agent: Optional[str] = Field(default="claude-cli/2.1.85")
+    user_agent: Optional[str] = Field(default=DEFAULT_USER_AGENT)
 
     billing_header_mode: Literal["auto", "always", "never"] = Field(default="auto")
     cc_version: str = Field(default=DEFAULT_CC_VERSION)
@@ -185,7 +190,7 @@ class AnthropicOAuthLLM(CustomLLM):
         api_base: str = DEFAULT_API_BASE,
         anthropic_version: str = DEFAULT_ANTHROPIC_VERSION,
         oauth_beta: str = DEFAULT_OAUTH_BETA,
-        user_agent: Optional[str] = "claude-cli/2.1.85",
+        user_agent: Optional[str] = DEFAULT_USER_AGENT,
         billing_header_mode: Literal["auto", "always", "never"] = "auto",
         cc_version: str = DEFAULT_CC_VERSION,
         cc_entrypoint: str = DEFAULT_CC_ENTRYPOINT,
@@ -239,7 +244,7 @@ class AnthropicOAuthLLM(CustomLLM):
             num_output=self.max_tokens or -1,
             model_name=self.model,
             is_chat_model=True,
-            is_function_calling_model=True,
+            is_function_calling_model=self.model != ANTHROPIC_FABLE_5_1_MODEL,
         )
 
     def _load_credentials_from_file(self, credential_path: str) -> None:

--- a/mobilerun/agent/utils/oauth/gemini_oauth_code_assist_llm.py
+++ b/mobilerun/agent/utils/oauth/gemini_oauth_code_assist_llm.py
@@ -376,14 +376,25 @@ class GeminiOAuthCodeAssistLLM(CustomLLM):
         for model_id, meta in models.items():
             if not isinstance(meta, dict) or model_id in deprecated:
                 continue
-            if meta.get("isInternal") or not meta.get("displayName"):
+            if meta.get("isInternal"):
                 continue
             if "GEMINI" not in str(meta.get("apiProvider") or ""):
+                continue
+            display_name = meta.get("displayName")
+            is_tiered_model = (
+                isinstance(model_id, str)
+                and model_id.startswith("gemini-")
+                and model_id.endswith("-tiered")
+            )
+            # The live Antigravity catalog omits displayName for its public
+            # tiered agent models. Keep requiring a name for every other model
+            # so nameless tab/aux entries are not exposed as user choices.
+            if not display_name and not is_tiered_model:
                 continue
             out.append(
                 {
                     "id": model_id,
-                    "display_name": meta.get("displayName"),
+                    "display_name": display_name or model_id,
                     "supports_images": bool(meta.get("supportsImages")),
                 }
             )

--- a/mobilerun/agent/utils/oauth/gemini_oauth_code_assist_llm.py
+++ b/mobilerun/agent/utils/oauth/gemini_oauth_code_assist_llm.py
@@ -32,6 +32,7 @@ from llama_index.core.constants import DEFAULT_TEMPERATURE
 from llama_index.core.llms.callbacks import llm_chat_callback, llm_completion_callback
 from llama_index.core.llms.custom import CustomLLM
 
+from mobilerun.agent.providers.registry import model_display_name_for_variant
 from mobilerun.agent.utils.oauth.login_timeout import (
     OAuthLoginDeadline,
     open_browser_async,
@@ -391,10 +392,13 @@ class GeminiOAuthCodeAssistLLM(CustomLLM):
             # so nameless tab/aux entries are not exposed as user choices.
             if not display_name and not is_tiered_model:
                 continue
+            friendly_name = model_display_name_for_variant("gemini", "oauth", model_id)
+            if friendly_name == model_id:
+                friendly_name = display_name or model_id
             out.append(
                 {
                     "id": model_id,
-                    "display_name": display_name or model_id,
+                    "display_name": friendly_name,
                     "supports_images": bool(meta.get("supportsImages")),
                 }
             )

--- a/mobilerun/agent/utils/oauth/openai_oauth_llm.py
+++ b/mobilerun/agent/utils/oauth/openai_oauth_llm.py
@@ -27,7 +27,7 @@ from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler
 from http.server import ThreadingHTTPServer as HTTPServer
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Literal, Optional
 from urllib.parse import parse_qs, urlencode, urlparse
 
 import httpx
@@ -63,6 +63,12 @@ DEFAULT_OPENAI_OAUTH_SCOPE = (
     "openid profile email offline_access api.connectors.read api.connectors.invoke"
 )
 _OPENAI_LOGIN_TIMEOUT_MESSAGE = "OpenAI OAuth login timed out."
+_GPT_6_ASTRA_MODEL = "gpt-6-astra"
+_GPT_6_ASTRA_REASONING_EFFORTS = frozenset({"low", "medium", "high", "xhigh", "max"})
+_GPT_6_ASTRA_UNSUPPORTED_PARAMS = frozenset(
+    {"temperature", "top_p", "logprobs", "top_logprobs"}
+)
+_GPT_6_ASTRA_UNSUPPORTED_INCLUDE = "message.output_text.logprobs"
 
 
 def _b64_no_pad(raw: bytes) -> str:
@@ -579,6 +585,10 @@ class OpenAIOAuthSessionManager:
 class OpenAIOAuth(OpenAI):
     """OpenAI LLM backed by ChatGPT OAuth refresh/access tokens."""
 
+    reasoning_effort: Optional[
+        Literal["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+    ] = None
+
     @classmethod
     def class_name(cls) -> str:
         return "OpenAIOAuth"
@@ -1053,6 +1063,43 @@ class OpenAIOAuth(OpenAI):
 
         return normalized
 
+    def _sanitize_gpt_6_astra_kwargs(
+        self, runtime_kwargs: dict[str, Any]
+    ) -> dict[str, Any]:
+        if self.model != _GPT_6_ASTRA_MODEL:
+            return runtime_kwargs
+
+        merged: dict[str, Any] = {}
+        if self.reasoning_effort is not None:
+            merged["reasoning"] = {"effort": self.reasoning_effort}
+        merged.update(self.additional_kwargs or {})
+        merged.update(runtime_kwargs)
+
+        for key in _GPT_6_ASTRA_UNSUPPORTED_PARAMS:
+            merged.pop(key, None)
+
+        include = merged.get("include")
+        if isinstance(include, (list, tuple)):
+            filtered_include = [
+                value for value in include if value != _GPT_6_ASTRA_UNSUPPORTED_INCLUDE
+            ]
+            merged["include"] = filtered_include or None
+
+        reasoning = merged.get("reasoning")
+        if reasoning is not None and not isinstance(reasoning, dict):
+            raise ValueError(
+                f"{_GPT_6_ASTRA_MODEL} reasoning must be a mapping with an "
+                "optional 'effort' value."
+            )
+        effort = reasoning.get("effort") if isinstance(reasoning, dict) else None
+        if effort is not None and effort not in _GPT_6_ASTRA_REASONING_EFFORTS:
+            supported = "low, medium, high, xhigh, or max"
+            raise ValueError(
+                f"{_GPT_6_ASTRA_MODEL} does not support reasoning effort "
+                f"{effort!r}; use {supported}."
+            )
+        return merged
+
     def _collect_stream_text_sync(self, events: Any) -> tuple[str, Any]:
         text_parts: list[str] = []
         final_response: Any = None
@@ -1121,6 +1168,7 @@ class OpenAIOAuth(OpenAI):
 
     @llm_retry_decorator
     def _chat(self, messages: list[ChatMessage], **kwargs: Any) -> ChatResponse:
+        kwargs = self._sanitize_gpt_6_astra_kwargs(kwargs)
         self._ensure_access_token()
         client = self._get_client()
         payload = self._build_responses_payload(messages)
@@ -1163,6 +1211,7 @@ class OpenAIOAuth(OpenAI):
 
     @llm_retry_decorator
     async def _achat(self, messages: list[ChatMessage], **kwargs: Any) -> ChatResponse:
+        kwargs = self._sanitize_gpt_6_astra_kwargs(kwargs)
         self._ensure_access_token()
         aclient = self._get_aclient()
         payload = self._build_responses_payload(messages)

--- a/mobilerun/cli/configure_prompts.py
+++ b/mobilerun/cli/configure_prompts.py
@@ -52,13 +52,39 @@ def select_prompt(
     for index, choice in enumerate(choices, start=1):
         suffix = f" - {choice.hint}" if choice.hint else ""
         click.echo(f"  {index}. {choice.label}{suffix}")
-    valid_values = [choice.value for choice in choices]
-    return click.prompt(
-        "Select option",
-        type=click.Choice(valid_values, case_sensitive=False),
-        default=default or valid_values[0],
-        show_choices=True,
+
+    default_index = next(
+        (
+            index
+            for index, choice in enumerate(choices, start=1)
+            if default is not None and choice.value.casefold() == default.casefold()
+        ),
+        1,
     )
+    while True:
+        response = click.prompt(
+            "Select option",
+            type=str,
+            default=str(default_index),
+            show_choices=False,
+        ).strip()
+        if response.isdecimal():
+            selected_index = int(response)
+            if 1 <= selected_index <= len(choices):
+                return choices[selected_index - 1].value
+
+        normalized_response = response.casefold()
+        for choice in choices:
+            if normalized_response in {
+                choice.label.casefold(),
+                choice.value.casefold(),
+            }:
+                return choice.value
+
+        click.echo(
+            f"Please enter a number from 1 to {len(choices)} or a listed label.",
+            err=True,
+        )
 
 
 def text_prompt(

--- a/mobilerun/cli/configure_wizard.py
+++ b/mobilerun/cli/configure_wizard.py
@@ -15,6 +15,7 @@ from mobilerun.agent.providers.minimax import (
 )
 from mobilerun.agent.providers.registry import (
     VARIANT_ENV_KEY_SLOT,
+    model_display_name_for_variant,
     resolve_provider_variant,
 )
 from mobilerun.agent.providers.setup_service import (
@@ -102,6 +103,8 @@ def _print_configure_intro(console: Console) -> None:
 def _print_configure_summary(
     console: Console,
     *,
+    family_id: str,
+    auth_mode: str,
     provider_label: str,
     variant_id: str,
     model: str,
@@ -109,10 +112,11 @@ def _print_configure_summary(
 ) -> None:
     advanced_line = "Yes" if used_advanced_settings else "No"
     provider_detail = "" if provider_label == "XAI" else f" ({variant_id})"
+    model_label = model_display_name_for_variant(family_id, auth_mode, model)
     console.print(
         Panel(
             f"Provider: {provider_label}{provider_detail}\n"
-            f"Model: {model}\n"
+            f"Model: {model_label}\n"
             f"Advanced settings changed: {advanced_line}",
             title="Configuration Saved",
             border_style="green",
@@ -142,6 +146,8 @@ def _prompt_float(console: Console, message: str, default: float) -> float:
 def _prompt_model_choice(
     models: list[str],
     *,
+    family_id: str,
+    auth_mode: str,
     default_model: str,
     allow_back: bool = True,
 ) -> str:
@@ -149,7 +155,15 @@ def _prompt_model_choice(
         choice = _select_with_back(
             "Choose model",
             [
-                *[SelectChoice(value=item, label=item) for item in models],
+                *[
+                    SelectChoice(
+                        value=item,
+                        label=model_display_name_for_variant(
+                            family_id, auth_mode, item
+                        ),
+                    )
+                    for item in models
+                ],
                 SelectChoice(
                     value="enter_model",
                     label="Enter custom model",
@@ -553,6 +567,8 @@ def _configure_provider_model(
             while True:
                 state.selected_model = _prompt_model_choice(
                     models,
+                    family_id=state.family_id,
+                    auth_mode=state.selected_auth_mode,
                     default_model=default_model,
                 )
                 if state.selected_model == _BACK:
@@ -716,6 +732,8 @@ def run_configure_wizard(
             ConfigLoader.save(config)
             _print_configure_summary(
                 console,
+                family_id=state.family_id or "",
+                auth_mode=state.selected_auth_mode or "",
                 provider_label=family_labels[state.family_id],
                 variant_id=state.last_variant_id or state.family_id,
                 model=state.selected_model or "",
@@ -771,6 +789,8 @@ def run_configure_wizard(
             if provider_configured and state.family_id:
                 _print_configure_summary(
                     console,
+                    family_id=state.family_id,
+                    auth_mode=state.selected_auth_mode or "",
                     provider_label=family_labels[state.family_id],
                     variant_id=state.last_variant_id or state.family_id,
                     model=state.selected_model or "",

--- a/tests/test_anthropic_oauth_llm.py
+++ b/tests/test_anthropic_oauth_llm.py
@@ -1,8 +1,12 @@
 import pytest
 from llama_index.core.base.llms.types import ChatMessage, MessageRole
 
+from mobilerun.agent.providers.anthropic import ANTHROPIC_HIGHRES_MODELS
 from mobilerun.agent.utils.oauth.anthropic_oauth_llm import (
+    DEFAULT_CC_VERSION,
+    DEFAULT_CLAUDE_CODE_VERSION,
     DEFAULT_MAX_TOKENS,
+    DEFAULT_USER_AGENT,
     AnthropicOAuthLLM,
 )
 
@@ -23,13 +27,15 @@ class _FakeResponse:
 class _CapturingSession:
     def __init__(self):
         self.payload = None
+        self.headers = None
 
     def post(self, url, headers, json, timeout):
         self.payload = dict(json)
+        self.headers = dict(headers)
         return _FakeResponse()
 
 
-def _payload_for(**kwargs):
+def _session_for(**kwargs):
     llm = AnthropicOAuthLLM(
         access_token="test-token",
         credential_path=None,
@@ -38,7 +44,11 @@ def _payload_for(**kwargs):
     session = _CapturingSession()
     llm._session = session
     llm.chat([ChatMessage(role=MessageRole.USER, content="hello")])
-    return session.payload
+    return session
+
+
+def _payload_for(**kwargs):
+    return _session_for(**kwargs).payload
 
 
 def test_default_max_tokens_is_8192():
@@ -67,6 +77,7 @@ def test_opus_4_8_payload_sends_max_tokens_without_temperature():
     [
         ("claude-opus-5", 1_000_000),
         ("claude-sonnet-5", 1_000_000),
+        ("claude-fable-5-1", 1_000_000),
         ("claude-fable-5", 1_000_000),
         ("claude-opus-4-8", 1_000_000),
         ("claude-opus-4-7", 1_000_000),
@@ -87,6 +98,7 @@ def test_current_model_metadata_has_verified_context_window(model, context_windo
     [
         "claude-opus-5",
         "claude-sonnet-5",
+        "claude-fable-5-1",
         "claude-fable-5",
         "claude-opus-4-8",
         "claude-opus-4-7",
@@ -112,6 +124,58 @@ def test_models_without_sampling_strip_all_final_payload_overrides(model):
 
     assert session.payload["model"] == model
     assert {"temperature", "top_p", "top_k"}.isdisjoint(session.payload)
+
+
+def test_fable_5_1_uses_high_resolution_vision_budget():
+    assert "claude-fable-5-1" in ANTHROPIC_HIGHRES_MODELS
+
+
+def test_fable_5_1_uses_current_claude_code_identity_defaults():
+    session = _session_for(model="claude-fable-5-1")
+
+    assert DEFAULT_CLAUDE_CODE_VERSION == "2.1.259"
+    assert DEFAULT_USER_AGENT == "claude-cli/2.1.259"
+    assert DEFAULT_CC_VERSION == "2.1.259.000"
+    assert session.headers["User-Agent"] == DEFAULT_USER_AGENT
+    assert f"cc_version={DEFAULT_CC_VERSION};" in session.payload["system"][0]["text"]
+
+
+def test_fable_5_1_structured_predict_uses_text_pydantic_extraction(monkeypatch):
+    from llama_index.core.base.llms.types import ChatResponse
+    from llama_index.core.prompts import PromptTemplate
+    from pydantic import BaseModel
+
+    class StructuredResult(BaseModel):
+        value: str
+
+    llm = AnthropicOAuthLLM(
+        model="claude-fable-5-1",
+        access_token="test-token",
+        credential_path=None,
+    )
+    monkeypatch.setattr(
+        type(llm),
+        "chat",
+        lambda _self, _messages, **_kwargs: ChatResponse(
+            message=ChatMessage(
+                role=MessageRole.ASSISTANT,
+                content='{"value":"OK"}',
+            )
+        ),
+    )
+
+    result = llm.structured_predict(
+        StructuredResult,
+        PromptTemplate("Return {value}."),
+        value="OK",
+    )
+
+    assert llm.metadata.is_function_calling_model is False
+    assert result == StructuredResult(value="OK")
+    assert (
+        AnthropicOAuthLLM(credential_path=None).metadata.is_function_calling_model
+        is True
+    )
 
 
 @pytest.mark.parametrize("model", ["claude-opus-4-6", "claude-sonnet-4-6"])

--- a/tests/test_configure_prompts.py
+++ b/tests/test_configure_prompts.py
@@ -1,0 +1,165 @@
+from io import StringIO
+
+import pytest
+from rich.console import Console
+
+import mobilerun.cli.configure_prompts as configure_prompts
+import mobilerun.cli.configure_wizard as configure_wizard
+from mobilerun.cli.configure_prompts import SelectChoice
+from mobilerun.cli.configure_wizard import ConfigureWizardCallbacks
+from mobilerun.config_manager import MobileConfig
+
+
+def test_inquirer_select_displays_label_and_returns_canonical_value(
+    monkeypatch,
+) -> None:
+    captured = {}
+
+    class FakePrompt:
+        def execute(self):
+            return "gemini-3.8-flash-tiered"
+
+    class FakeInquirer:
+        def select(self, **kwargs):
+            captured.update(kwargs)
+            return FakePrompt()
+
+    monkeypatch.setattr(
+        configure_prompts,
+        "_import_inquirer_select",
+        lambda: FakeInquirer(),
+    )
+
+    selected = configure_prompts.select_prompt(
+        "Choose model",
+        [
+            SelectChoice(
+                value="gemini-3.8-flash-tiered",
+                label="gemini-3.8-flash",
+            )
+        ],
+        default="gemini-3.8-flash-tiered",
+    )
+
+    assert selected == "gemini-3.8-flash-tiered"
+    assert captured["choices"] == [
+        {"name": "• gemini-3.8-flash", "value": "gemini-3.8-flash-tiered"}
+    ]
+    assert captured["default"] == "gemini-3.8-flash-tiered"
+
+
+@pytest.mark.parametrize(
+    "response",
+    (
+        "2",
+        "gemini-3.8-flash",
+        "GEMINI-3.8-FLASH-TIERED",
+        None,
+    ),
+)
+def test_click_fallback_returns_canonical_value_without_listing_raw_values(
+    monkeypatch, capsys, response: str | None
+) -> None:
+    prompt_calls = []
+    monkeypatch.setattr(configure_prompts, "_import_inquirer_select", lambda: None)
+
+    def fake_prompt(message, **kwargs):
+        prompt_calls.append((message, kwargs))
+        return kwargs["default"] if response is None else response
+
+    monkeypatch.setattr(configure_prompts.click, "prompt", fake_prompt)
+
+    selected = configure_prompts.select_prompt(
+        "Choose model",
+        [
+            SelectChoice(
+                value="gemini-3.7-flash-tiered",
+                label="gemini-3.7-flash",
+            ),
+            SelectChoice(
+                value="gemini-3.8-flash-tiered",
+                label="gemini-3.8-flash",
+            ),
+        ],
+        default="gemini-3.8-flash-tiered",
+    )
+
+    assert selected == "gemini-3.8-flash-tiered"
+    assert prompt_calls == [
+        (
+            "Select option",
+            {
+                "type": str,
+                "default": "2",
+                "show_choices": False,
+            },
+        )
+    ]
+    output = capsys.readouterr().out
+    assert "1. gemini-3.7-flash" in output
+    assert "2. gemini-3.8-flash" in output
+    assert "gemini-3.7-flash-tiered" not in output
+    assert "gemini-3.8-flash-tiered" not in output
+
+
+def test_gemini_oauth_picker_saves_canonical_id_but_summarizes_display_name(
+    monkeypatch,
+) -> None:
+    config = MobileConfig()
+    saved_configs = []
+    login_calls = []
+    picker_choices = []
+
+    monkeypatch.setattr(configure_wizard.ConfigLoader, "load", lambda: config)
+    monkeypatch.setattr(
+        configure_wizard.ConfigLoader,
+        "save",
+        lambda saved: saved_configs.append(saved),
+    )
+    monkeypatch.setattr(
+        configure_wizard,
+        "_oauth_credentials_present",
+        lambda credential_path, variant_id: False,
+    )
+
+    def select_tiered_model(message, choices, **kwargs):
+        assert message == "Choose model"
+        picker_choices.extend(choices)
+        return next(
+            choice.value for choice in choices if choice.label == "gemini-3.8-flash"
+        )
+
+    monkeypatch.setattr(configure_wizard, "_select_with_back", select_tiered_model)
+    output = StringIO()
+
+    configure_wizard.run_configure_wizard(
+        Console(file=output, force_terminal=False, width=120),
+        ConfigureWizardCallbacks(
+            run_openai_oauth_login=lambda **kwargs: None,
+            run_anthropic_oauth_login=lambda **kwargs: None,
+            run_gemini_oauth_login=lambda **kwargs: login_calls.append(kwargs),
+        ),
+        provider="gemini",
+        auth_mode="oauth",
+        model=None,
+        api_key=None,
+        base_url=None,
+    )
+
+    canonical_id = "gemini-3.8-flash-tiered"
+    assert any(
+        choice.value == canonical_id and choice.label == "gemini-3.8-flash"
+        for choice in picker_choices
+    )
+    assert saved_configs == [config]
+    assert login_calls[0]["model"] == canonical_id
+    assert all(
+        profile.model == canonical_id for profile in config.llm_profiles.values()
+    )
+    assert all(
+        profile["model"] == canonical_id
+        for profile in config.to_dict()["llm_profiles"].values()
+    )
+    summary = output.getvalue()
+    assert "Model: gemini-3.8-flash" in summary
+    assert canonical_id not in summary

--- a/tests/test_gemini_oauth_llm.py
+++ b/tests/test_gemini_oauth_llm.py
@@ -196,7 +196,7 @@ def _models_from_catalog(payload):
     return llm.fetch_available_models(access_token="catalog-token")
 
 
-def test_fetch_available_models_accepts_nameless_tiered_gemini_entries():
+def test_fetch_available_models_uses_friendly_names_for_tiered_gemini_entries():
     models = _models_from_catalog(
         {
             "models": {
@@ -220,12 +220,12 @@ def test_fetch_available_models_accepts_nameless_tiered_gemini_entries():
     assert models == [
         {
             "id": "gemini-3.8-flash-tiered",
-            "display_name": "gemini-3.8-flash-tiered",
+            "display_name": "gemini-3.8-flash",
             "supports_images": True,
         },
         {
             "id": "gemini-3.7-flash-tiered",
-            "display_name": "gemini-3.7-flash-tiered",
+            "display_name": "gemini-3.7-flash",
             "supports_images": True,
         },
         {
@@ -233,6 +233,37 @@ def test_fetch_available_models_accepts_nameless_tiered_gemini_entries():
             "display_name": "Gemini 3.6 Flash (High)",
             "supports_images": True,
         },
+    ]
+
+
+@pytest.mark.parametrize(
+    ("model_id", "expected_display_name"),
+    [
+        ("gemini-3.8-flash-tiered", "gemini-3.8-flash"),
+        ("gemini-3.7-flash-tiered", "gemini-3.7-flash"),
+    ],
+)
+def test_fetch_available_models_overrides_tiered_provider_display_name(
+    model_id: str, expected_display_name: str
+) -> None:
+    models = _models_from_catalog(
+        {
+            "models": {
+                model_id: {
+                    "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
+                    "displayName": f"Google label for {model_id}",
+                    "supportsImages": True,
+                }
+            }
+        }
+    )
+
+    assert models == [
+        {
+            "id": model_id,
+            "display_name": expected_display_name,
+            "supports_images": True,
+        }
     ]
 
 

--- a/tests/test_gemini_oauth_llm.py
+++ b/tests/test_gemini_oauth_llm.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from llama_index.core.base.llms.types import ChatMessage, MessageRole
 
@@ -12,12 +14,14 @@ from mobilerun.agent.utils.llm_picker import load_llm
 @pytest.mark.parametrize(
     "model",
     (
+        "gemini-3.8-flash-tiered",
+        "gemini-3.7-flash-tiered",
         "gemini-3.6-flash-low",
         "gemini-3.6-flash-medium",
         "gemini-3.6-flash-high",
     ),
 )
-def test_gemini_oauth_profile_sends_new_effort_models_verbatim(
+def test_gemini_oauth_profile_sends_supported_models_verbatim(
     tmp_path, model: str
 ) -> None:
     variant = resolve_provider_variant("gemini", "oauth")
@@ -47,12 +51,225 @@ def test_gemini_oauth_profile_sends_new_effort_models_verbatim(
     assert payload["model"] == model
 
 
-def _gemini_llm():
+def _gemini_llm(model: str | None = None):
     from mobilerun.agent.utils.oauth.gemini_oauth_code_assist_llm import (
         GeminiOAuthCodeAssistLLM,
     )
 
-    return GeminiOAuthCodeAssistLLM(access_token="test-token", credential_path=None)
+    kwargs = {"model": model} if model is not None else {}
+    return GeminiOAuthCodeAssistLLM(
+        access_token="test-token", credential_path=None, **kwargs
+    )
+
+
+class _SSEStreamResponse:
+    ok = True
+    status_code = 200
+    text = ""
+
+    def __init__(self, chunks):
+        self.chunks = chunks
+
+    def raise_for_status(self):
+        return None
+
+    def iter_lines(self, decode_unicode):
+        assert decode_unicode is True
+        for chunk in self.chunks:
+            yield f"data: {json.dumps(chunk)}"
+            yield ""
+
+
+class _SSESession:
+    def __init__(self, chunks):
+        self.chunks = chunks
+        self.calls = []
+
+    def post(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        return _SSEStreamResponse(self.chunks)
+
+
+def _text_chunk(text: str, *, final: bool = False):
+    response = {
+        "candidates": [{"content": {"parts": [{"text": text}]}}],
+    }
+    if final:
+        response.update(
+            {
+                "usageMetadata": {"totalTokenCount": 4},
+                "modelVersion": "tiered-test-version",
+            }
+        )
+    return {"traceId": f"trace-{text}", "response": response}
+
+
+@pytest.mark.parametrize(
+    "model", ("gemini-3.8-flash-tiered", "gemini-3.7-flash-tiered")
+)
+def test_tiered_complete_routes_exact_model_over_sse(model: str) -> None:
+    llm = _gemini_llm(model)
+    session = _SSESession([_text_chunk("O"), _text_chunk("K", final=True)])
+    llm._session = session
+
+    response = llm.complete("Reply OK", generation_config={"temperature": 0.2})
+
+    assert response.text == "OK"
+    assert response.additional_kwargs == {
+        "trace_id": "trace-K",
+        "usage": {"totalTokenCount": 4},
+        "model_version": "tiered-test-version",
+    }
+    [(url, call)] = session.calls
+    assert url.endswith("/v1internal:streamGenerateContent")
+    assert call["params"] == {"alt": "sse"}
+    assert call["headers"]["Accept"] == "text/event-stream"
+    assert call["stream"] is True
+    assert call["json"]["model"] == model
+    request = call["json"]["request"]
+    assert request["generationConfig"] == {"temperature": 0.2}
+    assert request["contents"] == [{"role": "user", "parts": [{"text": "Reply OK"}]}]
+
+
+@pytest.mark.parametrize(
+    "model", ("gemini-3.8-flash-tiered", "gemini-3.7-flash-tiered")
+)
+def test_tiered_stream_chat_routes_exact_model_and_image_payload(model: str) -> None:
+    import base64
+
+    from llama_index.core.base.llms.types import ImageBlock, TextBlock
+
+    png = _tiny_image("PNG")
+    llm = _gemini_llm(model)
+    session = _SSESession([_text_chunk("first"), _text_chunk(" second")])
+    llm._session = session
+
+    chunks = list(
+        llm.stream_chat(
+            [
+                ChatMessage(
+                    role=MessageRole.USER,
+                    blocks=[TextBlock(text="Inspect"), ImageBlock(image=png)],
+                )
+            ],
+            generation_config={"temperature": 0.2},
+        )
+    )
+
+    assert [chunk.delta for chunk in chunks] == ["first", " second"]
+    assert [chunk.message.content for chunk in chunks] == ["first", "first second"]
+    [(url, call)] = session.calls
+    assert url.endswith("/v1internal:streamGenerateContent")
+    assert call["params"] == {"alt": "sse"}
+    assert call["stream"] is True
+    assert call["json"]["model"] == model
+    request = call["json"]["request"]
+    assert request["generationConfig"] == {"temperature": 0.2}
+    parts = request["contents"][0]["parts"]
+    assert parts[0] == {"text": "Inspect"}
+    assert parts[1]["inlineData"]["mimeType"] == "image/png"
+    assert base64.b64decode(parts[1]["inlineData"]["data"]) == png
+
+
+class _CatalogResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self.payload
+
+
+class _CatalogSession:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def post(self, url, headers, json, timeout):
+        return _CatalogResponse(self.payload)
+
+
+def _models_from_catalog(payload):
+    llm = _gemini_llm()
+    llm._session = _CatalogSession(payload)
+    return llm.fetch_available_models(access_token="catalog-token")
+
+
+def test_fetch_available_models_accepts_nameless_tiered_gemini_entries():
+    models = _models_from_catalog(
+        {
+            "models": {
+                "gemini-3.8-flash-tiered": {
+                    "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
+                    "supportsImages": True,
+                },
+                "gemini-3.7-flash-tiered": {
+                    "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
+                    "supportsImages": True,
+                },
+                "gemini-3.6-flash-high": {
+                    "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
+                    "displayName": "Gemini 3.6 Flash (High)",
+                    "supportsImages": True,
+                },
+            }
+        }
+    )
+
+    assert models == [
+        {
+            "id": "gemini-3.8-flash-tiered",
+            "display_name": "gemini-3.8-flash-tiered",
+            "supports_images": True,
+        },
+        {
+            "id": "gemini-3.7-flash-tiered",
+            "display_name": "gemini-3.7-flash-tiered",
+            "supports_images": True,
+        },
+        {
+            "id": "gemini-3.6-flash-high",
+            "display_name": "Gemini 3.6 Flash (High)",
+            "supports_images": True,
+        },
+    ]
+
+
+def test_fetch_available_models_rejects_unsafe_nameless_or_hidden_entries():
+    models = _models_from_catalog(
+        {
+            "models": {
+                "gemini-command-aux": {
+                    "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
+                },
+                "gemini-internal-tiered": {
+                    "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
+                    "isInternal": True,
+                },
+                "gemini-deprecated-tiered": {
+                    "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
+                },
+                "gemini-wrong-provider-tiered": {
+                    "apiProvider": "API_PROVIDER_OTHER",
+                },
+                "gemini-malformed-tiered": "not metadata",
+                "gemini-visible": {
+                    "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
+                    "displayName": "Gemini Visible",
+                },
+            },
+            "deprecatedModelIds": {"gemini-deprecated-tiered": {}},
+        }
+    )
+
+    assert models == [
+        {
+            "id": "gemini-visible",
+            "display_name": "Gemini Visible",
+            "supports_images": False,
+        }
+    ]
 
 
 def _tiny_image(fmt: str) -> bytes:

--- a/tests/test_grok_cli.py
+++ b/tests/test_grok_cli.py
@@ -243,7 +243,9 @@ def test_exact_xai_configure_forms_keep_provider_and_auth_fixed(
         lambda saved: saved_configs.append(saved),
     )
 
-    def choose_model(models, *, default_model, allow_back=True):  # type: ignore[no-untyped-def]
+    def choose_model(  # type: ignore[no-untyped-def]
+        models, *, family_id, auth_mode, default_model, allow_back=True
+    ):
         model_prompts.append((tuple(models), default_model))
         return default_model
 
@@ -351,7 +353,9 @@ def test_fixed_provider_and_auth_model_back_returns_to_top_level_once(
         lambda saved: saved_configs.append(saved),
     )
 
-    def choose_model(models, *, default_model, allow_back=True):  # type: ignore[no-untyped-def]
+    def choose_model(  # type: ignore[no-untyped-def]
+        models, *, family_id, auth_mode, default_model, allow_back=True
+    ):
         model_prompts.append((tuple(models), default_model))
         return configure_wizard._BACK
 

--- a/tests/test_llm_picker.py
+++ b/tests/test_llm_picker.py
@@ -37,6 +37,7 @@ def test_normalize_provider_name_accepts_user_facing_aliases(
 @pytest.mark.parametrize(
     "model",
     [
+        "gpt-6-astra",
         "gpt-5.5",
         "gpt-5.6-sol",
         "gpt-5.6-terra",
@@ -66,6 +67,7 @@ def test_openai_responses_current_reasoning_models_omit_sampling_params(
 @pytest.mark.parametrize(
     "model",
     [
+        "gpt-6-astra",
         "gpt-5.5",
         "gpt-5.6-sol",
         "gpt-5.6-terra",
@@ -102,6 +104,8 @@ def test_openai_structured_predict_omits_per_call_sampling_params(
     call_kwargs = {
         "temperature": 0.4,
         "top_p": 0.6,
+        "top_logprobs": 2,
+        "logprobs": True,
         "max_output_tokens": 32,
     }
 
@@ -124,12 +128,15 @@ def test_openai_structured_predict_omits_per_call_sampling_params(
     assert async_result.value == "OK"
     for payload in (sync_payload, async_payload):
         assert {"temperature", "top_p"}.isdisjoint(payload)
+        if model == "gpt-6-astra":
+            assert {"top_logprobs", "logprobs"}.isdisjoint(payload)
         assert payload["max_output_tokens"] == 32
 
 
 @pytest.mark.parametrize(
     ("model", "context_window"),
     [
+        ("gpt-6-astra", 1_050_000),
         ("gpt-5.5", 1_050_000),
         ("gpt-5.6-sol", 1_050_000),
         ("gpt-5.6-terra", 1_050_000),
@@ -164,6 +171,179 @@ def test_openai_responses_preserves_explicit_context_window_override() -> None:
     )
 
     assert llm.metadata.context_window == 123_456
+
+
+def test_openai_astra_preserves_explicit_context_window_override() -> None:
+    llm = load_llm(
+        "OpenAIResponses",
+        model="gpt-6-astra",
+        api_key="stub",
+        context_window=123_456,
+    )
+
+    assert llm.metadata.context_window == 123_456
+
+
+def test_openai_astra_strips_logprob_configuration_and_forwards_reasoning() -> None:
+    llm = load_llm(
+        "OpenAIResponses",
+        model="gpt-6-astra",
+        api_key="stub",
+        temperature=0.4,
+        top_p=0.6,
+        include=["message.output_text.logprobs", "reasoning.encrypted_content"],
+        reasoning_options={"effort": "max", "summary": "auto"},
+        additional_kwargs={
+            "model": "gpt-5.5",
+            "top_logprobs": 2,
+            "logprobs": True,
+        },
+    )
+
+    kwargs = llm._get_model_kwargs(
+        temperature=0.7,
+        top_p=0.8,
+        include=("message.output_text.logprobs", "reasoning.encrypted_content"),
+        extra_body={
+            "model": "gpt-5.5",
+            "temperature": 0.9,
+            "top_p": 0.9,
+            "top_logprobs": 3,
+            "logprobs": True,
+            "include": (
+                "message.output_text.logprobs",
+                "reasoning.encrypted_content",
+            ),
+            "reasoning": {"effort": "high"},
+        },
+    )
+
+    assert {"temperature", "top_p", "top_logprobs", "logprobs"}.isdisjoint(kwargs)
+    assert kwargs["model"] == "gpt-6-astra"
+    assert kwargs["include"] == ["reasoning.encrypted_content"]
+    assert kwargs["reasoning"] == {"effort": "max", "summary": "auto"}
+    extra_body = kwargs["extra_body"]
+    assert {
+        "model",
+        "temperature",
+        "top_p",
+        "top_logprobs",
+        "logprobs",
+    }.isdisjoint(extra_body)
+    assert extra_body["include"] == ["reasoning.encrypted_content"]
+    assert extra_body["reasoning"] == {"effort": "high"}
+
+
+@pytest.mark.parametrize("effort", ["low", "medium", "high", "xhigh", "max"])
+def test_openai_astra_accepts_supported_reasoning_effort(effort: str) -> None:
+    llm = load_llm(
+        "OpenAIResponses",
+        model="gpt-6-astra",
+        api_key="stub",
+        reasoning_options={"effort": effort},
+    )
+
+    assert llm._get_model_kwargs()["reasoning"] == {"effort": effort}
+
+
+@pytest.mark.parametrize("effort", ["none", "minimal", "unsupported"])
+def test_openai_astra_rejects_unsupported_reasoning_effort(effort: str) -> None:
+    llm = load_llm(
+        "OpenAIResponses",
+        model="gpt-6-astra",
+        api_key="stub",
+        reasoning_options={"effort": effort},
+    )
+
+    with pytest.raises(ValueError, match="does not support reasoning effort"):
+        llm._get_model_kwargs()
+
+
+@pytest.mark.parametrize("effort", ["none", "minimal", "unsupported"])
+def test_openai_astra_rejects_unsupported_extra_body_reasoning(
+    effort: str,
+) -> None:
+    llm = load_llm(
+        "OpenAIResponses",
+        model="gpt-6-astra",
+        api_key="stub",
+    )
+
+    with pytest.raises(ValueError, match="does not support reasoning effort"):
+        llm._get_model_kwargs(
+            extra_body={"reasoning": {"effort": effort}},
+        )
+
+
+def test_openai_astra_structured_requests_retain_configured_options() -> None:
+    from llama_index.core.prompts import PromptTemplate
+    from pydantic import BaseModel
+
+    class StructuredResult(BaseModel):
+        value: str
+
+    sync_payload: dict[str, Any] = {}
+    async_payload: dict[str, Any] = {}
+
+    def parse_sync(**kwargs: Any) -> Any:
+        sync_payload.update(kwargs)
+        return SimpleNamespace(output_parsed=StructuredResult(value="OK"))
+
+    async def parse_async(**kwargs: Any) -> Any:
+        async_payload.update(kwargs)
+        return SimpleNamespace(output_parsed=StructuredResult(value="OK"))
+
+    llm = load_llm(
+        "OpenAIResponses",
+        model="gpt-6-astra",
+        api_key="stub",
+        include=["message.output_text.logprobs", "reasoning.encrypted_content"],
+        reasoning_options={"effort": "max", "summary": "auto"},
+        additional_kwargs={
+            "temperature": 0.4,
+            "top_logprobs": 2,
+            "extra_body": {
+                "top_p": 0.6,
+                "include": (
+                    "message.output_text.logprobs",
+                    "reasoning.encrypted_content",
+                ),
+            },
+        },
+    )
+    llm._client = SimpleNamespace(responses=SimpleNamespace(parse=parse_sync))
+    llm._aclient = SimpleNamespace(responses=SimpleNamespace(parse=parse_async))
+    prompt = PromptTemplate("Return {value}")
+    call_kwargs = {
+        "logprobs": True,
+        "top_p": 0.8,
+        "max_output_tokens": 32,
+    }
+
+    sync_result = llm.structured_predict(
+        StructuredResult,
+        prompt,
+        llm_kwargs=dict(call_kwargs),
+        value="OK",
+    )
+    async_result = asyncio.run(
+        llm.astructured_predict(
+            StructuredResult,
+            prompt,
+            llm_kwargs=dict(call_kwargs),
+            value="OK",
+        )
+    )
+
+    assert sync_result.value == "OK"
+    assert async_result.value == "OK"
+    for payload in (sync_payload, async_payload):
+        assert payload["model"] == "gpt-6-astra"
+        assert payload["reasoning"] == {"effort": "max", "summary": "auto"}
+        assert payload["include"] == ["reasoning.encrypted_content"]
+        assert payload["max_output_tokens"] == 32
+        assert {"temperature", "top_p", "top_logprobs", "logprobs"}.isdisjoint(payload)
+        assert payload["extra_body"] == {"include": ["reasoning.encrypted_content"]}
 
 
 def test_openai_alias_loads_openai_responses_without_temperature_for_gpt_5_5() -> None:
@@ -233,6 +413,7 @@ def test_openai_oauth_rejects_unsupported_codex_model() -> None:
 @pytest.mark.parametrize(
     "model",
     [
+        "gemini-3.8-flash",
         "gemini-3.7-flash",
         "gemini-3.6-flash",
         "gemini-3.5-flash-lite",
@@ -263,7 +444,12 @@ def test_gemini_oauth_allows_live_unadvertised_2_5_ids(model: str) -> None:
 
 @pytest.mark.parametrize(
     "model",
-    ["gemini-3.7-flash", "gemini-3.6-flash", "gemini-3.5-flash-lite"],
+    [
+        "gemini-3.8-flash",
+        "gemini-3.7-flash",
+        "gemini-3.6-flash",
+        "gemini-3.5-flash-lite",
+    ],
 )
 def test_new_google_genai_models_omit_sampling_configuration(model: str) -> None:
     from google.genai import types
@@ -304,7 +490,10 @@ def test_new_google_genai_models_omit_sampling_configuration(model: str) -> None
     assert call_kwargs["generation_config"] == {"max_output_tokens": 32}
 
 
-def test_gemini_3_7_image_tool_chat_uses_native_payload_without_sampling() -> None:
+@pytest.mark.parametrize("model", ["gemini-3.7-flash", "gemini-3.8-flash"])
+def test_gemini_image_tool_chat_uses_native_payload_without_sampling(
+    model: str,
+) -> None:
     from google.genai import types
     from llama_index.core.base.llms.types import (
         ChatMessage,
@@ -349,7 +538,7 @@ def test_gemini_3_7_image_tool_chat_uses_native_payload_without_sampling() -> No
 
     llm = load_llm(
         "GoogleGenAI",
-        model="gemini-3.7-flash",
+        model=model,
         api_key="stub",
         context_window=1_048_576,
         max_tokens=64,
@@ -389,7 +578,7 @@ def test_gemini_3_7_image_tool_chat_uses_native_payload_without_sampling() -> No
 
     create_kwargs = captured["create"]
     config = create_kwargs["config"].model_dump(exclude_none=True)
-    assert create_kwargs["model"] == llm.model == "gemini-3.7-flash"
+    assert create_kwargs["model"] == llm.model == model
     assert {"temperature", "top_p", "top_k"}.isdisjoint(config)
     assert config["max_output_tokens"] == 32
     assert config["tools"][0]["function_declarations"][0]["name"] == "live_probe"
@@ -452,7 +641,9 @@ class _AsyncStructuredModelsCapture:
         return _AsyncChunks([SimpleNamespace(parsed=self._output, candidates=[])])
 
 
-def _google_structured_llm_with_capture() -> tuple[Any, Any, Any, list[dict[str, Any]]]:
+def _google_structured_llm_with_capture(
+    model: str = "gemini-3.7-flash",
+) -> tuple[Any, Any, Any, list[dict[str, Any]]]:
     from llama_index.core.prompts import PromptTemplate
     from pydantic import BaseModel
 
@@ -463,7 +654,7 @@ def _google_structured_llm_with_capture() -> tuple[Any, Any, Any, list[dict[str,
     calls: list[dict[str, Any]] = []
     llm = load_llm(
         "GoogleGenAI",
-        model="gemini-3.7-flash",
+        model=model,
         api_key="stub",
         max_tokens=64,
         context_window=1_000_000,
@@ -497,7 +688,8 @@ def _assert_google_request_omits_sampling(request: dict[str, Any]) -> None:
     assert sampling_params.isdisjoint(request["config"])
 
 
-def test_gemini_3_7_chat_paths_strip_sampling_payload(monkeypatch) -> None:
+@pytest.mark.parametrize("model", ["gemini-3.7-flash", "gemini-3.8-flash"])
+def test_gemini_chat_paths_strip_sampling_payload(monkeypatch, model: str) -> None:
     from llama_index.llms.google_genai import GoogleGenAI
 
     calls: list[tuple[str, dict[str, Any]]] = []
@@ -525,7 +717,7 @@ def test_gemini_3_7_chat_paths_strip_sampling_payload(monkeypatch) -> None:
 
     llm = load_llm(
         "GoogleGenAI",
-        model="gemini-3.7-flash",
+        model=model,
         api_key="stub",
         max_tokens=64,
         context_window=1_000_000,
@@ -552,8 +744,9 @@ def test_gemini_3_7_chat_paths_strip_sampling_payload(monkeypatch) -> None:
         assert call_kwargs["generation_config"] == {"max_output_tokens": 32}
 
 
-def test_google_direct_structured_path_strips_sampling_payload() -> None:
-    llm, output_cls, prompt, calls = _google_structured_llm_with_capture()
+@pytest.mark.parametrize("model", ["gemini-3.7-flash", "gemini-3.8-flash"])
+def test_google_direct_structured_path_strips_sampling_payload(model: str) -> None:
+    llm, output_cls, prompt, calls = _google_structured_llm_with_capture(model)
 
     result = llm.structured_predict_without_function_calling(
         output_cls,
@@ -573,10 +766,11 @@ def test_google_direct_structured_path_strips_sampling_payload() -> None:
         ("stream_structured_predict", True),
     ],
 )
+@pytest.mark.parametrize("model", ["gemini-3.7-flash", "gemini-3.8-flash"])
 def test_google_sync_structured_paths_strip_sampling_payload(
-    method_name: str, streaming: bool
+    method_name: str, streaming: bool, model: str
 ) -> None:
-    llm, output_cls, prompt, calls = _google_structured_llm_with_capture()
+    llm, output_cls, prompt, calls = _google_structured_llm_with_capture(model)
 
     result = getattr(llm, method_name)(
         output_cls,
@@ -592,9 +786,10 @@ def test_google_sync_structured_paths_strip_sampling_payload(
     assert calls[-1]["config"]["max_output_tokens"] == 32
 
 
-def test_google_async_structured_paths_strip_sampling_payload() -> None:
+@pytest.mark.parametrize("model", ["gemini-3.7-flash", "gemini-3.8-flash"])
+def test_google_async_structured_paths_strip_sampling_payload(model: str) -> None:
     async def run() -> None:
-        llm, output_cls, prompt, calls = _google_structured_llm_with_capture()
+        llm, output_cls, prompt, calls = _google_structured_llm_with_capture(model)
 
         result = await llm.astructured_predict(
             output_cls,
@@ -659,7 +854,7 @@ def test_gemini_oauth_supported_choices_come_from_registry() -> None:
         load_llm("gemini_oauth_code_assist", model="gemini-3.5-flash")
 
 
-@pytest.mark.parametrize("model", ["claude-opus-4-8"])
+@pytest.mark.parametrize("model", ["claude-opus-4-8", "claude-fable-5-1"])
 def test_anthropic_opus_4_omits_default_temperature(model: str) -> None:
     llm = load_llm(
         "Anthropic",
@@ -755,6 +950,53 @@ def test_anthropic_profile_uses_the_shared_2048_token_default() -> None:
     assert llm.max_tokens == 2048
 
 
+def test_anthropic_fable_5_1_uses_text_structured_output_fallback(
+    monkeypatch,
+) -> None:
+    from llama_index.core.base.llms.types import ChatMessage, ChatResponse
+    from llama_index.core.prompts import PromptTemplate
+    from llama_index.core.types import PydanticProgramMode
+    from pydantic import BaseModel
+
+    class StructuredResult(BaseModel):
+        value: str
+
+    llm = load_llm(
+        "Anthropic",
+        model="claude-fable-5-1",
+        api_key="stub",
+    )
+    monkeypatch.setattr(
+        type(llm),
+        "chat",
+        lambda _self, _messages, **_kwargs: ChatResponse(
+            message=ChatMessage(role="assistant", content='{"value":"OK"}')
+        ),
+    )
+
+    result = llm.structured_predict(
+        StructuredResult,
+        PromptTemplate("Return {value}."),
+        value="OK",
+    )
+
+    assert llm.pydantic_program_mode is PydanticProgramMode.LLM
+    assert result == StructuredResult(value="OK")
+
+
+def test_anthropic_fable_5_1_overrides_unsupported_function_program_mode() -> None:
+    from llama_index.core.types import PydanticProgramMode
+
+    llm = load_llm(
+        "Anthropic",
+        model="claude-fable-5-1",
+        api_key="stub",
+        pydantic_program_mode=PydanticProgramMode.FUNCTION,
+    )
+
+    assert llm.pydantic_program_mode is PydanticProgramMode.LLM
+
+
 @pytest.mark.parametrize("max_tokens", [512, 4096])
 def test_anthropic_preserves_explicit_max_tokens(max_tokens: int) -> None:
     llm = load_llm(
@@ -771,6 +1013,7 @@ def test_anthropic_preserves_explicit_max_tokens(max_tokens: int) -> None:
 @pytest.mark.parametrize(
     ("model", "context_window"),
     [
+        ("claude-fable-5-1", 1_000_000),
         ("claude-opus-5", 1_000_000),
         ("claude-sonnet-5", 1_000_000),
         ("claude-fable-5", 1_000_000),
@@ -797,7 +1040,12 @@ def test_anthropic_current_catalog_models_have_metadata(
 
 @pytest.mark.parametrize(
     "model",
-    ["claude-opus-5", "claude-sonnet-5", "claude-fable-5"],
+    [
+        "claude-fable-5-1",
+        "claude-opus-5",
+        "claude-sonnet-5",
+        "claude-fable-5",
+    ],
 )
 def test_anthropic_claude_5_models_strip_all_sampling_overrides(model: str) -> None:
     llm = load_llm(

--- a/tests/test_minimax_configuration.py
+++ b/tests/test_minimax_configuration.py
@@ -301,8 +301,12 @@ def test_minimax_wizard_defaults_to_m3_for_each_region(
     state = ConfigureWizardState(family_id="minimax")
     captured = {}
 
-    def choose_default_model(models, *, default_model, allow_back=True):
+    def choose_default_model(
+        models, *, family_id, auth_mode, default_model, allow_back=True
+    ):
         captured["models"] = models
+        captured["family_id"] = family_id
+        captured["auth_mode"] = auth_mode
         captured["default_model"] = default_model
         captured["allow_back"] = allow_back
         return default_model
@@ -344,6 +348,8 @@ def test_minimax_wizard_defaults_to_m3_for_each_region(
 
     assert configured is True
     assert captured["models"][0] == "MiniMax-M3"
+    assert captured["family_id"] == "minimax"
+    assert captured["auth_mode"] == "api_key"
     assert captured["default_model"] == "MiniMax-M3"
     assert state.selected_model == "MiniMax-M3"
     for profile in config.llm_profiles.values():

--- a/tests/test_openai_oauth_llm.py
+++ b/tests/test_openai_oauth_llm.py
@@ -1,4 +1,7 @@
+import asyncio
 import json
+from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 from llama_index.core.base.llms.types import (
@@ -16,9 +19,26 @@ from mobilerun.agent.providers.setup_service import (
 from mobilerun.agent.utils.oauth.openai_oauth_llm import OpenAIOAuth
 
 
-def _offline_oauth_llm(tmp_path) -> OpenAIOAuth:
+class _AsyncEvents:
+    def __init__(self, events):
+        self._events = iter(events)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._events)
+        except StopIteration:
+            raise StopAsyncIteration from None
+
+    async def aclose(self):
+        return None
+
+
+def _offline_oauth_llm(tmp_path, model: str = "gpt-5.5") -> OpenAIOAuth:
     return OpenAIOAuth(
-        model="gpt-5.5",
+        model=model,
         oauth_access_token="stub-access-token",
         oauth_expires_at_ms=4_102_444_800_000,
         oauth_credential_path=str(tmp_path / "auth-profiles.json"),
@@ -150,3 +170,191 @@ def test_openai_oauth_preserves_text_and_serializes_tool_arguments(tmp_path) -> 
     assert json.loads(tool_item["arguments"]) == {"package": "com.android.settings"}
     assert tool_item["call_id"] == "call-1"
     assert tool_item["name"] == "start_app"
+
+
+@pytest.mark.parametrize("effort", (None, "low", "medium", "high", "xhigh", "max"))
+def test_gpt_6_astra_forwards_supported_reasoning_only(
+    tmp_path, monkeypatch, effort: str | None
+) -> None:
+    llm = OpenAIOAuth(
+        model="gpt-6-astra",
+        reasoning_effort=effort,
+        oauth_access_token="stub-access-token",
+        oauth_expires_at_ms=4_102_444_800_000,
+        oauth_credential_path=str(tmp_path / "auth-profiles.json"),
+        max_tokens=256,
+        additional_kwargs={
+            "include": (
+                "message.output_text.logprobs",
+                "reasoning.encrypted_content",
+            )
+        },
+    )
+    create_response = Mock(
+        return_value=[
+            SimpleNamespace(type="response.output_text.delta", delta="OK"),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(output_text="OK"),
+            ),
+        ]
+    )
+    client = SimpleNamespace(responses=SimpleNamespace(create=create_response))
+    monkeypatch.setattr(OpenAIOAuth, "_get_client", lambda _self: client)
+
+    runtime_kwargs = {
+        "temperature": 0.7,
+        "top_p": 0.8,
+        "logprobs": True,
+        "top_logprobs": 5,
+    }
+    llm._chat(
+        [ChatMessage(role=MessageRole.USER, content="Reply with OK.")],
+        **runtime_kwargs,
+    )
+
+    request = create_response.call_args.kwargs
+    assert request["model"] == "gpt-6-astra"
+    assert llm.metadata.context_window == 400_000
+    if effort is None:
+        assert "reasoning" not in request
+    else:
+        assert request["reasoning"] == {"effort": effort}
+    assert request["include"] == ["reasoning.encrypted_content"]
+    assert {"temperature", "top_p", "logprobs", "top_logprobs"}.isdisjoint(request)
+
+
+@pytest.mark.parametrize("effort", ("none", "minimal"))
+def test_gpt_6_astra_rejects_unsupported_reasoning_before_request(
+    tmp_path, monkeypatch, effort: str
+) -> None:
+    llm = OpenAIOAuth(
+        model="gpt-6-astra",
+        reasoning_effort=effort,
+        oauth_access_token="stub-access-token",
+        oauth_expires_at_ms=4_102_444_800_000,
+        oauth_credential_path=str(tmp_path / "auth-profiles.json"),
+        max_tokens=256,
+    )
+    create_response = Mock()
+    client = SimpleNamespace(responses=SimpleNamespace(create=create_response))
+    monkeypatch.setattr(OpenAIOAuth, "_get_client", lambda _self: client)
+
+    with pytest.raises(ValueError, match=rf"reasoning effort '{effort}'"):
+        llm._chat(
+            [ChatMessage(role=MessageRole.USER, content="Reply with OK.")],
+        )
+
+    create_response.assert_not_called()
+
+
+@pytest.mark.parametrize("source", ("additional_kwargs", "runtime"))
+@pytest.mark.parametrize("effort", ("none", "minimal", "unsupported"))
+def test_gpt_6_astra_rejects_invalid_final_merged_reasoning(
+    tmp_path, monkeypatch, source: str, effort: str
+) -> None:
+    additional_kwargs = (
+        {"reasoning": {"effort": effort}} if source == "additional_kwargs" else None
+    )
+    runtime_kwargs = {"reasoning": {"effort": effort}} if source == "runtime" else {}
+    llm = OpenAIOAuth(
+        model="gpt-6-astra",
+        reasoning_effort="low",
+        oauth_access_token="stub-access-token",
+        oauth_expires_at_ms=4_102_444_800_000,
+        oauth_credential_path=str(tmp_path / "auth-profiles.json"),
+        additional_kwargs=additional_kwargs,
+    )
+    create_response = Mock()
+    client = SimpleNamespace(responses=SimpleNamespace(create=create_response))
+    monkeypatch.setattr(OpenAIOAuth, "_get_client", lambda _self: client)
+
+    with pytest.raises(ValueError, match=rf"reasoning effort '{effort}'"):
+        llm._chat(
+            [ChatMessage(role=MessageRole.USER, content="Reply with OK.")],
+            **runtime_kwargs,
+        )
+
+    create_response.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("source", "effort"),
+    (("additional_kwargs", "xhigh"), ("runtime", "max")),
+)
+def test_gpt_6_astra_accepts_supported_final_merged_reasoning(
+    tmp_path, source: str, effort: str
+) -> None:
+    additional_kwargs = (
+        {"reasoning": {"effort": effort}} if source == "additional_kwargs" else None
+    )
+    runtime_kwargs = {"reasoning": {"effort": effort}} if source == "runtime" else {}
+    llm = OpenAIOAuth(
+        model="gpt-6-astra",
+        reasoning_effort="low",
+        oauth_access_token="stub-access-token",
+        oauth_expires_at_ms=4_102_444_800_000,
+        oauth_credential_path=str(tmp_path / "auth-profiles.json"),
+        additional_kwargs=additional_kwargs,
+    )
+
+    assert llm._sanitize_gpt_6_astra_kwargs(runtime_kwargs)["reasoning"] == {
+        "effort": effort
+    }
+
+
+def test_gpt_6_astra_async_request_uses_exact_model_and_reasoning(
+    tmp_path, monkeypatch
+) -> None:
+    llm = OpenAIOAuth(
+        model="gpt-6-astra",
+        reasoning_effort="low",
+        oauth_access_token="stub-access-token",
+        oauth_expires_at_ms=4_102_444_800_000,
+        oauth_credential_path=str(tmp_path / "auth-profiles.json"),
+        max_tokens=256,
+    )
+    calls = []
+
+    async def create(**kwargs):
+        calls.append(kwargs)
+        return _AsyncEvents(
+            [
+                SimpleNamespace(type="response.output_text.delta", delta="OK"),
+                SimpleNamespace(
+                    type="response.completed",
+                    response=SimpleNamespace(output_text="OK"),
+                ),
+            ]
+        )
+
+    client = SimpleNamespace(responses=SimpleNamespace(create=create))
+    monkeypatch.setattr(OpenAIOAuth, "_get_aclient", lambda _self: client)
+
+    response = asyncio.run(
+        llm._achat(
+            [ChatMessage(role=MessageRole.USER, content="Reply with OK.")],
+            temperature=0.7,
+            top_logprobs=5,
+        )
+    )
+
+    assert response.message.content == "OK"
+    assert calls == [
+        {
+            "input": [
+                {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "Reply with OK."}],
+                }
+            ],
+            "model": "gpt-6-astra",
+            "instructions": "You are a helpful coding assistant.",
+            "tools": [],
+            "tool_choice": "auto",
+            "parallel_tool_calls": True,
+            "store": False,
+            "stream": True,
+            "reasoning": {"effort": "low"},
+        }
+    ]

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -2,6 +2,7 @@ import pytest
 
 from mobilerun.agent.providers.registry import (
     list_models_for_variant,
+    model_display_name_for_variant,
     normalize_model_id_for_variant,
     resolve_provider_variant,
 )
@@ -52,6 +53,40 @@ def test_gemini_oauth_catalog_uses_antigravity_consumer_models() -> None:
     assert "gemini-3.5-flash" not in models
     assert "gemini-3.1-flash-lite" not in models
     assert "gemini-3.1-pro-high" not in models
+
+
+@pytest.mark.parametrize(
+    ("family_id", "auth_mode", "model_id", "expected"),
+    [
+        (
+            "gemini",
+            "oauth",
+            "gemini-3.8-flash-tiered",
+            "gemini-3.8-flash",
+        ),
+        (
+            "gemini",
+            "oauth",
+            "gemini-3.7-flash-tiered",
+            "gemini-3.7-flash",
+        ),
+        (
+            "gemini",
+            "oauth",
+            "gemini-3.6-flash-high",
+            "gemini-3.6-flash-high",
+        ),
+        ("gemini", "api_key", "gemini-3.8-flash", "gemini-3.8-flash"),
+        ("openai", "oauth", "gpt-6-astra", "gpt-6-astra"),
+    ],
+)
+def test_model_display_names_preserve_canonical_ids_except_explicit_overrides(
+    family_id: str,
+    auth_mode: str,
+    model_id: str,
+    expected: str,
+) -> None:
+    assert model_display_name_for_variant(family_id, auth_mode, model_id) == expected
 
 
 def test_anthropic_catalogs_include_claude_5_without_changing_defaults() -> None:

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -16,6 +16,7 @@ def test_gemini_api_key_catalog_uses_current_flash_models() -> None:
     assert variant.default_model == "gemini-3.7-flash"
     assert models == (
         "gemini-3.7-flash",
+        "gemini-3.8-flash",
         "gemini-3.5-flash",
         "gemini-3.6-flash",
         "gemini-3.5-flash-lite",
@@ -33,6 +34,8 @@ def test_gemini_oauth_catalog_uses_antigravity_consumer_models() -> None:
     assert variant.default_model == "gemini-3.5-flash-low"
     assert models == (
         "gemini-3.5-flash-low",
+        "gemini-3.8-flash-tiered",
+        "gemini-3.7-flash-tiered",
         "gemini-3.5-flash-extra-low",
         "gemini-3-flash-agent",
         "gemini-3-flash",
@@ -60,6 +63,7 @@ def test_anthropic_catalogs_include_claude_5_without_changing_defaults() -> None
     assert api_key_variant.default_model == "claude-sonnet-4-6"
     assert api_key_models == (
         "claude-sonnet-4-6",
+        "claude-fable-5-1",
         "claude-opus-5",
         "claude-sonnet-5",
         "claude-fable-5",
@@ -70,6 +74,7 @@ def test_anthropic_catalogs_include_claude_5_without_changing_defaults() -> None
     assert oauth_variant.default_model == "claude-opus-4-7"
     assert oauth_models == (
         "claude-opus-4-7",
+        "claude-fable-5-1",
         "claude-opus-5",
         "claude-sonnet-5",
         "claude-fable-5",
@@ -87,6 +92,7 @@ def test_openai_oauth_catalog_hides_unsupported_codex_model() -> None:
     assert variant.default_model == "gpt-5.5"
     assert models == (
         "gpt-5.5",
+        "gpt-6-astra",
         "gpt-5.6-sol",
         "gpt-5.6-terra",
         "gpt-5.6-luna",
@@ -103,6 +109,7 @@ def test_openai_api_key_catalog_uses_current_default_model() -> None:
     assert variant.default_model == "gpt-5.5"
     assert models == (
         "gpt-5.5",
+        "gpt-6-astra",
         "gpt-5.6-sol",
         "gpt-5.6-terra",
         "gpt-5.6-luna",
@@ -131,6 +138,8 @@ def test_default_profiles_use_gemini_3_7_flash() -> None:
         ("oauth", "openai-codex/gpt-5.6", "gpt-5.6-sol"),
         ("api_key", "gpt-5.6-terra", "gpt-5.6-terra"),
         ("oauth", "gpt-5.6-luna", "gpt-5.6-luna"),
+        ("api_key", "gpt-6-astra", "gpt-6-astra"),
+        ("oauth", "gpt-6-astra", "gpt-6-astra"),
     ],
 )
 def test_openai_model_aliases_normalize_to_catalog_ids(
@@ -144,3 +153,8 @@ def test_openai_unknown_models_pass_through(auth_mode: str) -> None:
     model = "vendor/custom-model"
 
     assert normalize_model_id_for_variant("openai", auth_mode, model) == model
+
+
+@pytest.mark.parametrize("auth_mode", ["api_key", "oauth"])
+def test_openai_gpt_6_alias_is_not_invented(auth_mode: str) -> None:
+    assert normalize_model_id_for_variant("openai", auth_mode, "gpt-6") == "gpt-6"

--- a/tests/test_vision_sizing.py
+++ b/tests/test_vision_sizing.py
@@ -32,7 +32,12 @@ def test_model_effective_dims_per_provider():
 
 
 def test_claude_5_models_use_high_resolution_budget():
-    for model in ("claude-opus-5", "claude-sonnet-5", "claude-fable-5"):
+    for model in (
+        "claude-fable-5-1",
+        "claude-opus-5",
+        "claude-sonnet-5",
+        "claude-fable-5",
+    ):
         assert model_effective_dims(model, 1080, 2400) == (922, 2048)
 
 


### PR DESCRIPTION
## Summary

- add Gemini 3.8 Flash for API-key use and the 3.8/3.7 tiered OAuth catalog entries
- add Claude Fable 5.1 for API-key and OAuth use, including 1M context, vision sizing, sampling compatibility, and structured-output fallback
- add GPT-6 Astra for API-key and OAuth use, including Responses API metadata, merged-layer request sanitization, and reasoning validation
- keep all existing provider defaults unchanged; no xAI, dependency, lockfile, schema, Portal, telemetry, tracing, or package-version changes

## Validation

- 716 pytest tests and 3 subtests passed
- 241 focused provider/model tests passed
- Ruff, Black, uv lock --check, git diff --check, and package build passed
- live API-key and OAuth transport probes passed for every added model ID
- seven bounded Android 16 / SDK 36 emulator runs passed with Portal 0.7.22
- every run used stateful Manager/Executor reasoning, Manager vision on, Executor vision off, exact requested model routing, and independently verified Android 16
- streaming coverage: Gemini API, Gemini 3.8 OAuth, Claude API, and GPT API on; Gemini 3.7 OAuth, Claude OAuth, and GPT OAuth agent streaming off (GPT Responses transport streaming retained)

No credentials, model responses, goals, or device payloads are included in this PR.