### PR TITLE
fix: repair legacy compatibility contracts

### DIFF
--- a/mobilerun/__init__.py
+++ b/mobilerun/__init__.py
@@ -19,7 +19,7 @@ _logger.propagate = False
 
 # Import main classes for easier access
 from mobilerun.agent import ResultEvent  # noqa: E402
-from mobilerun.agent.droid import MobileAgent  # noqa: E402
+from mobilerun.agent.droid import MobileAgent, MobileAgentState  # noqa: E402
 from mobilerun.agent.utils.llm_picker import load_llm  # noqa: E402
 
 # Import configuration classes
@@ -53,6 +53,7 @@ from mobilerun.tools import AndroidDriver, DeviceDriver, RecordingDriver  # noqa
 __all__ = [
     # Agent
     "MobileAgent",
+    "MobileAgentState",
     "load_llm",
     "ResultEvent",
     # Tools / Drivers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ anthropic = [
     "anthropic>=0.67.0",
     "llama-index-llms-anthropic>=0.8.6,<0.9.0",
 ]
+deepseek = []
 dev = [
     "black==26.5.1",
     "ruff>=0.13.0",

--- a/tests/test_public_api_compatibility.py
+++ b/tests/test_public_api_compatibility.py
@@ -1,0 +1,52 @@
+import tomllib
+from pathlib import Path
+
+import pytest
+
+import mobilerun
+from mobilerun.agent.droid import MobileAgentState
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read_project(path: Path) -> dict:
+    with path.open("rb") as project_file:
+        return tomllib.load(project_file)["project"]
+
+
+def test_mobile_agent_state_is_exported_from_package_root():
+    assert mobilerun.MobileAgentState is MobileAgentState
+    assert "MobileAgentState" in mobilerun.__all__
+
+
+def test_legacy_droid_agent_state_alias_resolves_to_canonical_class():
+    with pytest.warns(
+        DeprecationWarning,
+        match="DroidAgentState has been renamed to MobileAgentState",
+    ):
+        assert mobilerun.DroidAgentState is MobileAgentState
+
+
+def test_legacy_droid_agent_state_can_be_imported_from_package_root():
+    with pytest.warns(
+        DeprecationWarning,
+        match="DroidAgentState has been renamed to MobileAgentState",
+    ):
+        from mobilerun import DroidAgentState
+
+    assert DroidAgentState is MobileAgentState
+
+
+def test_compatibility_package_uses_matching_exact_pins():
+    mobilerun_project = _read_project(REPOSITORY_ROOT / "pyproject.toml")
+    droidrun_project = _read_project(REPOSITORY_ROOT / "compat" / "pyproject.toml")
+    version = mobilerun_project["version"]
+
+    assert droidrun_project["version"] == version
+    assert droidrun_project["dependencies"] == [f"mobilerun=={version}"]
+
+    mobilerun_extras = mobilerun_project["optional-dependencies"]
+    droidrun_extras = droidrun_project["optional-dependencies"]
+    assert mobilerun_extras["deepseek"] == []
+    for extra in ("anthropic", "deepseek", "langfuse", "dev"):
+        assert droidrun_extras[extra] == [f"mobilerun[{extra}]=={version}"]

--- a/uv.lock
+++ b/uv.lock
@@ -1780,7 +1780,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.13.0" },
     { name = "safety", marker = "extra == 'dev'", specifier = ">=3.2.11" },
 ]
-provides-extras = ["anthropic", "dev", "langfuse"]
+provides-extras = ["anthropic", "deepseek", "dev", "langfuse"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

- export `MobileAgentState` from the package root so the deprecated `DroidAgentState` alias resolves correctly
- restore `mobilerun[deepseek]` as an empty compatibility extra backed by the existing OpenAI-compatible dependencies
- add regression coverage for root aliases and exact `droidrun` compatibility pins

## Validation

- `pytest -q`: 733 passed, 3 subtests passed
- `ruff check .`
- `black --check --diff .`
- `uv lock --check`
- package graph remains 196 packages with identical names and versions
- Mobilerun and Droidrun wheel/sdist builds and Twine checks
- Python 3.11 and 3.13 clean installs of both local wheels
- `droidrun[deepseek]` installs without a missing-extra warning
- `pip check` and root/shim class-identity checks on Python 3.11 and 3.13
