### PR TITLE
chore(release): bump to 0.6.18

### DIFF
--- a/compat/pyproject.toml
+++ b/compat/pyproject.toml
@@ -1,15 +1,15 @@
 [project]
 name = "droidrun"
-version = "0.6.17"
+version = "0.6.18"
 description = "Compatibility shim — droidrun has been renamed to mobilerun"
 requires-python = ">=3.11,<3.14"
-dependencies = ["mobilerun==0.6.17"]
+dependencies = ["mobilerun==0.6.18"]
 
 [project.optional-dependencies]
-anthropic = ["mobilerun[anthropic]==0.6.17"]
-deepseek = ["mobilerun[deepseek]==0.6.17"]
-langfuse = ["mobilerun[langfuse]==0.6.17"]
-dev = ["mobilerun[dev]==0.6.17"]
+anthropic = ["mobilerun[anthropic]==0.6.18"]
+deepseek = ["mobilerun[deepseek]==0.6.18"]
+langfuse = ["mobilerun[langfuse]==0.6.18"]
+dev = ["mobilerun[dev]==0.6.18"]
 
 [project.scripts]
 droidrun = "droidrun.cli_shim:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mobilerun"
-version = "0.6.17"
+version = "0.6.18"
 description = "A framework for controlling mobile devices through LLM agents"
 authors = [{ name = "Niels Schmidt", email = "niels@droidrun.ai" }]
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -1684,7 +1684,7 @@ wheels = [
 
 [[package]]
 name = "mobilerun"
-version = "0.6.17"
+version = "0.6.18"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- bump `mobilerun` from 0.6.17 to 0.6.18
- bump the `droidrun` compatibility package and all five exact Mobilerun pins to 0.6.18
- update only the local Mobilerun version in `uv.lock`
- preserve the 196-package dependency graph and the intentionally empty `mobilerun[deepseek]` extra

## Release highlights since 0.6.17

- honor configuration-based telemetry opt-out
- migrate Langfuse tracing to v4 and refresh high-severity dependencies
- add current Gemini, Claude, and GPT model support
- restore legacy package exports and compatibility extras
- refresh README demos and mobile-harness guidance

## Validation

- focused release-critical suite: 489 passed
- complete pytest suite: 733 passed, 3 subtests passed
- unittest discovery: 89 passed
- Ruff, Black 26.5.1, `uv lock --check`, and `git diff --check`: passed
- Mobilerun and Droidrun wheels/sdists: built and passed Twine checks
- clean Python 3.11 and 3.13 frozen installs: 196 compatible packages, `pip check` clean
- public imports and exact `MobileAgentState` / deprecated `DroidAgentState` identity: verified
- `droidrun[anthropic]` and `droidrun[deepseek]`: installed with exact Mobilerun 0.6.18 pins and no missing-extra warnings
- Portal compatibility resolver: Mobilerun 0.6.18 resolves to Portal 0.7.22

### Android 16 release gates

- target: `Medium_Phone_API_36.1`, Android 16 / SDK 36 QEMU; only its dynamic `emulator-*` serial was used
- Portal 0.7.22 package, provider, accessibility service, and ping: verified
- documented two-step non-streaming `OpenAIResponses` / `gpt-6-astra` smoke: passed on step 1, no device action
- vision-enabled Settings task: passed in four steps and reported Android 16; independently confirmed through `mobilerun_core`
- Langfuse 4.15.1 trace: one MobileAgent root, one FastAgent span, four exact `gpt-6-astra` generations, 27 unique observations, valid parentage, no error observations
- native Langfuse media: four unique non-empty PNG uploads, all metadata and signed-download checks returned HTTP 200; clean explicit flush
- PostHog telemetry and trajectory saving were disabled
- physical-phone gate explicitly waived for this release

## Security note

Dependabot currently reports one high-severity transitive NLTK advisory (`GHSA-8mgp-746c-j5xp`, `CVE-2026-81726`). NLTK 3.10.3 is the latest release, no patched version is available, it is pulled transitively through LlamaIndex, and Mobilerun does not call the affected APIs. This accepted advisory does not change dependencies in the release bump.
