### PR TITLE
fix(agent): bound final telemetry capture

### DIFF
--- a/mobilerun/agent/droid/droid_agent.py
+++ b/mobilerun/agent/droid/droid_agent.py
@@ -7,6 +7,7 @@ Architecture:
 - When reasoning=True: Uses Manager (planning) + Executor (action) workflows
 """
 
+import asyncio
 import logging
 import os
 import traceback
@@ -1068,29 +1069,7 @@ class MobileAgent(Workflow):
             or self._stream_screenshots
             or self.config.logging.save_trajectory != "none"
         ):
-            try:
-                screenshot = await self.action_ctx.driver.screenshot()
-                if screenshot:
-                    ctx.write_event_to_stream(ScreenshotEvent(screenshot=screenshot))
-                    parent_span = trace.get_current_span()
-                    record_langfuse_screenshot(
-                        screenshot,
-                        parent_span=parent_span,
-                        screenshots_enabled=self.config.tracing.langfuse_screenshots,
-                        vision_enabled=vision_any,
-                    )
-                    logger.debug("📸 Final screenshot captured")
-            except Exception as e:
-                logger.warning(f"Failed to capture final screenshot: {e}")
-
-            try:
-                ui_state = await self.state_provider.get_state()
-                ctx.write_event_to_stream(
-                    RecordUIStateEvent(ui_state=ui_state.elements)
-                )
-                logger.debug("📋 Final UI state captured")
-            except Exception as e:
-                logger.warning(f"Failed to capture final UI state: {e}")
+            await self._capture_final_telemetry(ctx, vision_any)
 
         # Save trajectory to disk
         if self.config.logging.save_trajectory != "none":
@@ -1114,6 +1093,53 @@ class MobileAgent(Workflow):
                 logger.warning(f"MCP cleanup error: {e}")
 
         return result
+
+    # Final screenshot + UI-state capture share ONE local hard deadline. They are
+    # observation-only telemetry that runs AFTER the agent's decision exists: a
+    # device endpoint that hangs (or keeps retrying inside the SDK) must never
+    # keep the ``finalize`` step active until the workflow-wide timeout cancels
+    # it and turns an already-produced result into a WorkflowTimeoutError.
+    # Class attribute (not config) so tests and embedders can shrink it.
+    final_telemetry_budget_seconds: float = 15.0
+
+    async def _capture_final_telemetry(self, ctx: Context, vision_any: bool) -> None:
+        budget = self.final_telemetry_budget_seconds
+        try:
+            await asyncio.wait_for(
+                self._capture_final_screenshot_and_state(ctx, vision_any),
+                timeout=budget,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Final screenshot/UI-state capture exceeded the %.1fs telemetry "
+                "budget; final telemetry dropped, task result unaffected",
+                budget,
+            )
+
+    async def _capture_final_screenshot_and_state(
+        self, ctx: Context, vision_any: bool
+    ) -> None:
+        try:
+            screenshot = await self.action_ctx.driver.screenshot()
+            if screenshot:
+                ctx.write_event_to_stream(ScreenshotEvent(screenshot=screenshot))
+                parent_span = trace.get_current_span()
+                record_langfuse_screenshot(
+                    screenshot,
+                    parent_span=parent_span,
+                    screenshots_enabled=self.config.tracing.langfuse_screenshots,
+                    vision_enabled=vision_any,
+                )
+                logger.debug("📸 Final screenshot captured")
+        except Exception as e:
+            logger.warning(f"Failed to capture final screenshot: {e}")
+
+        try:
+            ui_state = await self.state_provider.get_state()
+            ctx.write_event_to_stream(RecordUIStateEvent(ui_state=ui_state.elements))
+            logger.debug("📋 Final UI state captured")
+        except Exception as e:
+            logger.warning(f"Failed to capture final UI state: {e}")
 
     # ========================================================================
     # Event streaming

--- a/tests/test_finalize_telemetry_budget.py
+++ b/tests/test_finalize_telemetry_budget.py
@@ -1,0 +1,145 @@
+"""Final screenshot / UI-state capture is best-effort telemetry that must never
+turn an already-produced agent result into a workflow timeout.
+
+Regression for the 2026-09-07 Dev incident: the agent reached
+``complete(success=true)`` but the workflow failed after 120 s with
+``Currently active steps: finalize`` because the final screenshot kept
+retrying/hanging inside the device SDK.
+"""
+
+import asyncio
+import time
+from types import SimpleNamespace
+
+import mobilerun.agent.droid.droid_agent as droid_agent_module
+from mobilerun.agent.common.events import RecordUIStateEvent, ScreenshotEvent
+from mobilerun.agent.droid.droid_agent import MobileAgent
+from mobilerun.agent.droid.events import FinalizeEvent, ResultEvent
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+async def _hang_forever():
+    await asyncio.sleep(3600)
+
+
+def _finalizing_agent(monkeypatch, *, screenshot, get_state, budget: float):
+    """A MobileAgent stub carrying exactly the state ``finalize`` touches."""
+    monkeypatch.setattr(droid_agent_module, "capture", lambda *a, **k: None)
+
+    async def _flush(*a, **k):
+        return None
+
+    monkeypatch.setattr(droid_agent_module, "flush", _flush)
+    monkeypatch.setattr(droid_agent_module, "record_langfuse_screenshot", lambda *a, **k: None)
+
+    agent = object.__new__(MobileAgent)
+    agent.shared_state = SimpleNamespace(
+        workflow_completed=False,
+        step_number=1,
+        visited_packages=set(),
+        visited_activities=set(),
+        telemetry_config_enabled=False,
+    )
+    agent.user_id = None
+    agent.output_model = None
+    agent.config = SimpleNamespace(
+        agent=SimpleNamespace(
+            manager=SimpleNamespace(vision=True),
+            executor=SimpleNamespace(vision=False),
+            fast_agent=SimpleNamespace(vision=False),
+        ),
+        logging=SimpleNamespace(save_trajectory="none", debug=False),
+        tracing=SimpleNamespace(langfuse_screenshots=False),
+    )
+    agent._stream_screenshots = False
+    agent.action_ctx = SimpleNamespace(driver=SimpleNamespace(screenshot=screenshot))
+    agent.state_provider = SimpleNamespace(get_state=get_state)
+    agent.macro_recorder = None
+    agent.mcp_manager = None
+    agent.final_telemetry_budget_seconds = budget
+    return agent
+
+
+def _finalize(agent):
+    events = []
+    ctx = SimpleNamespace(write_event_to_stream=events.append)
+    started = time.monotonic()
+    result = _run(agent.finalize(ctx, FinalizeEvent(success=True, reason="done")))
+    return result, events, time.monotonic() - started
+
+
+def test_hung_final_screenshot_cannot_overturn_success(monkeypatch):
+    async def get_state():
+        return SimpleNamespace(elements=[])
+
+    agent = _finalizing_agent(
+        monkeypatch, screenshot=_hang_forever, get_state=get_state, budget=0.2
+    )
+
+    result, events, elapsed = _finalize(agent)
+
+    assert isinstance(result, ResultEvent)
+    assert result.success is True
+    assert result.reason == "done"
+    assert elapsed < 2.0, "finalize must return within its local telemetry budget"
+    # The hung screenshot AND the (never reached) UI-state read are both dropped.
+    assert not any(isinstance(e, (ScreenshotEvent, RecordUIStateEvent)) for e in events)
+
+
+def test_hung_final_ui_state_cannot_overturn_success(monkeypatch):
+    async def screenshot():
+        return b"png"
+
+    agent = _finalizing_agent(
+        monkeypatch, screenshot=screenshot, get_state=_hang_forever, budget=0.2
+    )
+
+    result, events, elapsed = _finalize(agent)
+
+    assert isinstance(result, ResultEvent)
+    assert result.success is True
+    assert elapsed < 2.0
+    # The screenshot that completed inside the budget is still emitted.
+    assert any(isinstance(e, ScreenshotEvent) for e in events)
+    assert not any(isinstance(e, RecordUIStateEvent) for e in events)
+
+
+def test_failing_final_screenshot_still_captures_ui_state(monkeypatch):
+    async def screenshot():
+        raise RuntimeError("HTTP 500 context deadline exceeded")
+
+    async def get_state():
+        return SimpleNamespace(elements=[{"index": 1, "text": "e1"}])
+
+    agent = _finalizing_agent(monkeypatch, screenshot=screenshot, get_state=get_state, budget=5.0)
+
+    result, events, _ = _finalize(agent)
+
+    assert result.success is True
+    assert not any(isinstance(e, ScreenshotEvent) for e in events)
+    ui = [e for e in events if isinstance(e, RecordUIStateEvent)]
+    assert len(ui) == 1 and ui[0].ui_state[0]["text"] == "e1"
+
+
+def test_normal_run_emits_final_screenshot_and_ui_state(monkeypatch):
+    async def screenshot():
+        return b"png"
+
+    async def get_state():
+        return SimpleNamespace(elements=[{"index": 1, "text": "e1"}])
+
+    agent = _finalizing_agent(monkeypatch, screenshot=screenshot, get_state=get_state, budget=5.0)
+
+    result, events, _ = _finalize(agent)
+
+    assert result.success is True
+    kinds = [type(e) for e in events]
+    assert kinds.count(ScreenshotEvent) == 1
+    assert kinds.count(RecordUIStateEvent) == 1
+
+
+def test_default_budget_is_well_below_typical_task_timeouts():
+    assert 0 < MobileAgent.final_telemetry_budget_seconds <= 30


### PR DESCRIPTION
## Problem

`MobileAgent.finalize` captures a final screenshot and a final UI state after the agent has already produced its decision. Both captures were wrapped in `try/except`, but had **no local deadline**: a device call that hangs or keeps retrying held the `finalize` step open until the workflow-wide timeout cancelled it. The visible symptom is a run that reached `complete(success=true)` and still ended in `WorkflowTimeoutError … Currently active steps: finalize`.

## Fix

- Final screenshot + final UI state run under **one shared hard budget** (`MobileAgent.final_telemetry_budget_seconds = 15.0`, a class attribute so embedders and tests can shrink it) via `asyncio.wait_for`.
- On expiry: a warning is logged (`Final screenshot/UI-state capture exceeded the … telemetry budget; final telemetry dropped, task result unaffected`) and the already-created `ResultEvent` is returned unchanged.
- Per-call failure handling is unchanged (a failing screenshot still lets the UI-state read run); normal runs still emit `ScreenshotEvent` + `RecordUIStateEvent`.
- The capture body moves into `_capture_final_screenshot_and_state`; no behavior change outside the deadline.

## Tests (`tests/test_finalize_telemetry_budget.py`)

- hung final screenshot → `ResultEvent(success=True)` within the budget, no telemetry events
- hung final UI state → success, screenshot still emitted, UI state dropped
- failing screenshot → UI state still captured
- normal run → exactly one screenshot + one UI-state event
- default budget sanity (≤ 30 s)

`pytest tests/test_finalize_telemetry_budget.py tests/test_manager_response_validation.py` → 50 passed. `ruff check` clean on the changed files (the module was already not `ruff format`-clean before this change and is left as is to avoid unrelated churn).

## Follow-up

A separate, smaller retry budget for observation-only device reads (screenshot / UI state) would complement this; the budget here bounds total time regardless of retry policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)