### PR TITLE
fix(agent): preserve task results during finalization

### DIFF
--- a/mobilerun/agent/droid/droid_agent.py
+++ b/mobilerun/agent/droid/droid_agent.py
@@ -95,6 +95,7 @@ from mobilerun.telemetry import (
     capture,
     flush,
 )
+from mobilerun.telemetry.phoenix import clean_span
 from mobilerun.tools.filters import ConciseFilter, DetailedFilter
 from mobilerun.tools.formatters import IndexedFormatter
 from mobilerun.tools.ui.ios_provider import IOSStateProvider
@@ -157,6 +158,22 @@ async def _run_finalize_stage(
             task.cancel()
             _ABANDONED_FINALIZE_TASKS.add(task)
             task.add_done_callback(_reap_abandoned_finalize_task)
+
+
+def _structured_output_extraction(
+    structured_agent: StructuredOutputAgent, ctx: Context
+) -> Awaitable[StopEvent]:
+    """Run direct extraction with the observations of the nested workflow path."""
+
+    @clean_span("StructuredOutputAgent.extract_structured_output")
+    async def extract() -> StopEvent:
+        return await structured_agent.extract_structured_output(ctx, StartEvent())
+
+    @clean_span("StructuredOutputAgent.run")
+    async def run() -> StopEvent:
+        return await extract()
+
+    return run()
 
 
 def _normalize_control_backend(control_backend: str | None) -> str | None:
@@ -1100,11 +1117,11 @@ class MobileAgent(Workflow):
                     pydantic_model=self.output_model,
                     answer_text=ev.reason,
                 )
-                # Avoid a nested workflow (and its tracing) during epilog; the
-                # step itself preserves extraction result and error semantics.
+                # Avoid a nested workflow during epilog while retaining its
+                # extraction-level observations and result parentage.
                 completed, extraction_event = await _run_finalize_stage(
                     "structured-output",
-                    structured_agent.extract_structured_output(ctx, StartEvent()),
+                    _structured_output_extraction(structured_agent, ctx),
                     pre_cleanup_deadline,
                     cap=_FINALIZE_BUDGET_SECONDS,
                 )

--- a/mobilerun/agent/droid/droid_agent.py
+++ b/mobilerun/agent/droid/droid_agent.py
@@ -428,20 +428,9 @@ class MobileAgent(Workflow):
             self.app_opener_llm = None
             self.structured_output_llm = None
 
-        if (
-            not self._using_external_agent
-            and self.config.logging.save_trajectory != "none"
-        ):
-            self.trajectory = Trajectory(
-                goal=self.shared_state.instruction,
-                base_path=self.config.logging.trajectory_path,
-            )
-            self.trajectory_writer = TrajectoryWriter(queue_size=300)
-            self.macro_recorder = MacroRecorder()
-        else:
-            self.trajectory = None
-            self.trajectory_writer = None
-            self.macro_recorder = None
+        self.trajectory = None
+        self.trajectory_writer = None
+        self.macro_recorder = None
 
         # Sub-agents are created in __init__ but wired up in start_handler
         if self._using_external_agent:
@@ -499,6 +488,22 @@ class MobileAgent(Workflow):
         )
         await ctx.store.set(_WORKFLOW_DEADLINE_KEY, workflow_deadline)
 
+    async def _initialize_run_trajectory(self) -> None:
+        """Create trajectory state and a writer owned by the current run."""
+        if self._using_external_agent or self.config.logging.save_trajectory == "none":
+            self.trajectory = None
+            self.trajectory_writer = None
+            self.macro_recorder = None
+            return
+
+        self.trajectory = Trajectory(
+            goal=self.shared_state.instruction,
+            base_path=self.config.logging.trajectory_path,
+        )
+        self.trajectory_writer = TrajectoryWriter(queue_size=300)
+        self.macro_recorder = MacroRecorder()
+        await self.trajectory_writer.start()
+
     # ========================================================================
     # start_handler — creates driver, registry, action_ctx
     # ========================================================================
@@ -512,9 +517,7 @@ class MobileAgent(Workflow):
             f"🚀 Running MobileAgent to achieve goal: {self.shared_state.instruction}"
         )
         ctx.write_event_to_stream(ev)
-
-        if self.trajectory_writer:
-            await self.trajectory_writer.start()
+        await self._initialize_run_trajectory()
 
         # ── 0. External agent — early exit ────────────────────────────
         if self._using_external_agent:

--- a/mobilerun/agent/droid/droid_agent.py
+++ b/mobilerun/agent/droid/droid_agent.py
@@ -117,6 +117,7 @@ _FINALIZE_TELEMETRY_SECONDS = 10.0
 _FINALIZE_TRAJECTORY_SECONDS = 30.0
 _FINALIZE_MCP_SECONDS = 3.0
 _FINALIZE_CLEANUP_MAX_FRACTION = 0.5
+_WORKFLOW_DEADLINE_KEY = "mobile_agent_workflow_deadline"
 _ABANDONED_FINALIZE_TASKS: set[asyncio.Task[Any]] = set()
 
 
@@ -130,10 +131,25 @@ def _reap_abandoned_finalize_task(task: asyncio.Task[Any]) -> None:
 
 
 async def _run_finalize_stage(
-    name: str, awaitable: Awaitable[Any], deadline: float, cap: float
+    name: str,
+    awaitable: Awaitable[Any],
+    deadline: float,
+    cap: float,
+    *,
+    continue_in_background: bool = False,
 ) -> tuple[bool, Any]:
     """Run one best-effort epilog stage without letting cancellation linger."""
-    task = asyncio.create_task(awaitable, name=f"mobile-agent-finalize-{name}")
+
+    async def background_operation() -> Any:
+        try:
+            async with asyncio.timeout(cap):
+                return await awaitable
+        except TimeoutError:
+            logger.warning("Final %s background cleanup timed out", name)
+            raise
+
+    operation = background_operation() if continue_in_background else awaitable
+    task = asyncio.create_task(operation, name=f"mobile-agent-finalize-{name}")
     try:
         remaining = min(cap, deadline - time.monotonic())
         if remaining <= 0:
@@ -155,7 +171,8 @@ async def _run_finalize_stage(
             return False, None
     finally:
         if not task.done():
-            task.cancel()
+            if not continue_in_background:
+                task.cancel()
             _ABANDONED_FINALIZE_TASKS.add(task)
             task.add_done_callback(_reap_abandoned_finalize_task)
 
@@ -471,12 +488,16 @@ class MobileAgent(Workflow):
 
     def run(self, *args, **kwargs) -> Awaitable[ResultEvent] | WorkflowHandler:
         apply_session_context()
-        runtime_timeout = self._timeout
-        self._workflow_deadline = (
-            time.monotonic() + runtime_timeout if runtime_timeout is not None else None
-        )
         handler = super().run(*args, **kwargs)  # type: ignore[assignment]
         return handler
+
+    async def _initialize_workflow_deadline(self, ctx: Context) -> None:
+        """Store a deadline owned by the runtime execution of this run."""
+        runtime_timeout = self._timeout
+        workflow_deadline = (
+            time.monotonic() + runtime_timeout if runtime_timeout is not None else None
+        )
+        await ctx.store.set(_WORKFLOW_DEADLINE_KEY, workflow_deadline)
 
     # ========================================================================
     # start_handler — creates driver, registry, action_ctx
@@ -486,6 +507,7 @@ class MobileAgent(Workflow):
     async def start_handler(
         self, ctx: Context, ev: StartEvent
     ) -> FastAgentExecuteEvent | ManagerInputEvent:
+        await self._initialize_workflow_deadline(ctx)
         logger.info(
             f"🚀 Running MobileAgent to achieve goal: {self.shared_state.instruction}"
         )
@@ -1080,7 +1102,7 @@ class MobileAgent(Workflow):
             structured_output=None,
         )
         now = time.monotonic()
-        workflow_deadline = getattr(self, "_workflow_deadline", None)
+        workflow_deadline = await ctx.store.get(_WORKFLOW_DEADLINE_KEY, default=None)
         workflow_limit = (
             workflow_deadline - _FINALIZE_SCHEDULING_RESERVE_SECONDS
             if workflow_deadline is not None
@@ -1233,6 +1255,7 @@ class MobileAgent(Workflow):
                         self.trajectory_writer.stop(),
                         deadline - mcp_reserve,
                         cap=_FINALIZE_TRAJECTORY_SECONDS,
+                        continue_in_background=True,
                     )
                     if trajectory_written and completed:
                         logger.info(
@@ -1249,6 +1272,7 @@ class MobileAgent(Workflow):
                     self.mcp_manager.disconnect_all(),
                     deadline,
                     cap=_FINALIZE_MCP_SECONDS,
+                    continue_in_background=True,
                 )
             except Exception as exc:
                 logger.warning("MCP cleanup setup failed: %s", exc)

--- a/mobilerun/agent/droid/droid_agent.py
+++ b/mobilerun/agent/droid/droid_agent.py
@@ -7,10 +7,12 @@ Architecture:
 - When reasoning=True: Uses Manager (planning) + Executor (action) workflows
 """
 
+import asyncio
 import logging
 import os
+import time
 import traceback
-from typing import TYPE_CHECKING, Awaitable, Type, Union
+from typing import TYPE_CHECKING, Any, Awaitable, Type, Union
 
 from async_adbutils import adb
 from llama_index.core.llms.llm import LLM
@@ -107,6 +109,54 @@ if TYPE_CHECKING:
 logger = logging.getLogger("mobilerun")
 
 _COORDINATE_TOOL_NAMES = {"click_at", "click_area", "long_press_at"}
+_FINALIZE_BUDGET_SECONDS = 60.0
+_FINALIZE_SCHEDULING_RESERVE_SECONDS = 1.0
+_FINALIZE_OBSERVATION_SECONDS = 15.0
+_FINALIZE_TELEMETRY_SECONDS = 10.0
+_FINALIZE_TRAJECTORY_SECONDS = 30.0
+_FINALIZE_MCP_SECONDS = 3.0
+_FINALIZE_CLEANUP_MAX_FRACTION = 0.5
+_ABANDONED_FINALIZE_TASKS: set[asyncio.Task[Any]] = set()
+
+
+def _reap_abandoned_finalize_task(task: asyncio.Task[Any]) -> None:
+    """Consume a task's terminal exception without waiting for it."""
+    _ABANDONED_FINALIZE_TASKS.discard(task)
+    try:
+        task.result()
+    except (asyncio.CancelledError, Exception):
+        pass
+
+
+async def _run_finalize_stage(
+    name: str, awaitable: Awaitable[Any], deadline: float, cap: float
+) -> tuple[bool, Any]:
+    """Run one best-effort epilog stage without letting cancellation linger."""
+    task = asyncio.create_task(awaitable, name=f"mobile-agent-finalize-{name}")
+    try:
+        remaining = min(cap, deadline - time.monotonic())
+        if remaining <= 0:
+            logger.debug("Skipping final %s: epilog budget exhausted", name)
+            return False, None
+        done, _ = await asyncio.wait({task}, timeout=remaining)
+        if not done:
+            logger.warning("Final %s timed out", name)
+            return False, None
+        try:
+            return True, task.result()
+        except asyncio.CancelledError:
+            # A best-effort child may cancel itself; only cancellation of this
+            # helper's await is an external cancellation of finalize.
+            logger.warning("Final %s was cancelled", name)
+            return False, None
+        except Exception as exc:
+            logger.warning("Final %s failed: %s", name, exc)
+            return False, None
+    finally:
+        if not task.done():
+            task.cancel()
+            _ABANDONED_FINALIZE_TASKS.add(task)
+            task.add_done_callback(_reap_abandoned_finalize_task)
 
 
 def _normalize_control_backend(control_backend: str | None) -> str | None:
@@ -404,6 +454,10 @@ class MobileAgent(Workflow):
 
     def run(self, *args, **kwargs) -> Awaitable[ResultEvent] | WorkflowHandler:
         apply_session_context()
+        runtime_timeout = self._timeout
+        self._workflow_deadline = (
+            time.monotonic() + runtime_timeout if runtime_timeout is not None else None
+        )
         handler = super().run(*args, **kwargs)  # type: ignore[assignment]
         return handler
 
@@ -1002,60 +1056,72 @@ class MobileAgent(Workflow):
 
     @step
     async def finalize(self, ctx: Context, ev: FinalizeEvent) -> ResultEvent:
-        self.shared_state.workflow_completed = True
-        ctx.write_event_to_stream(ev)
-        capture(
-            MobileAgentFinalizeEvent(
-                success=ev.success,
-                reason=ev.reason,
-                steps=self.shared_state.step_number,
-                unique_packages_count=len(self.shared_state.visited_packages),
-                unique_activities_count=len(self.shared_state.visited_activities),
-            ),
-            self.user_id,
-            config_enabled=self.shared_state.telemetry_config_enabled,
-        )
-        await flush(config_enabled=self.shared_state.telemetry_config_enabled)
-
-        # Base result with answer
         result = ResultEvent(
             success=ev.success,
             reason=ev.reason,
             steps=self.shared_state.step_number,
             structured_output=None,
         )
+        now = time.monotonic()
+        workflow_deadline = getattr(self, "_workflow_deadline", None)
+        workflow_limit = (
+            workflow_deadline - _FINALIZE_SCHEDULING_RESERVE_SECONDS
+            if workflow_deadline is not None
+            else float("inf")
+        )
+        deadline = min(now + _FINALIZE_BUDGET_SECONDS, workflow_limit)
+        saves_trajectory = self.config.logging.save_trajectory != "none"
+        has_mcp = self.mcp_manager is not None
+        available = max(0.0, deadline - now)
+        cleanup_reserve = 0.0
+        if saves_trajectory:
+            cleanup_demand = _FINALIZE_TRAJECTORY_SECONDS + (
+                _FINALIZE_MCP_SECONDS if has_mcp else 0.0
+            )
+            cleanup_reserve = min(
+                cleanup_demand, available * _FINALIZE_CLEANUP_MAX_FRACTION
+            )
+        elif has_mcp:
+            cleanup_reserve = min(
+                _FINALIZE_MCP_SECONDS,
+                available * _FINALIZE_CLEANUP_MAX_FRACTION,
+            )
+        pre_cleanup_deadline = deadline - cleanup_reserve
+
+        self.shared_state.workflow_completed = True
+        ctx.write_event_to_stream(ev)
 
         # Extract structured output if model was provided
         if self.output_model is not None and ev.reason:
             logger.debug("🔄 Running structured output extraction...")
-
             try:
                 structured_agent = StructuredOutputAgent(
                     llm=self.structured_output_llm,
                     pydantic_model=self.output_model,
                     answer_text=ev.reason,
-                    timeout=self.timeout,
                 )
-
-                handler = structured_agent.run()
-
-                async for nested_ev in handler.stream_events():
-                    self.handle_stream_event(nested_ev, ctx)
-
-                extraction_result = await handler
-
-                if extraction_result["success"]:
-                    result.structured_output = extraction_result["structured_output"]
+                # Avoid a nested workflow (and its tracing) during epilog; the
+                # step itself preserves extraction result and error semantics.
+                completed, extraction_event = await _run_finalize_stage(
+                    "structured-output",
+                    structured_agent.extract_structured_output(ctx, StartEvent()),
+                    pre_cleanup_deadline,
+                    cap=_FINALIZE_BUDGET_SECONDS,
+                )
+                if completed and extraction_event.result["success"]:
+                    result.structured_output = extraction_event.result[
+                        "structured_output"
+                    ]
                     logger.debug("✅ Structured output added to final result")
-                else:
-                    logger.warning(
-                        f"⚠️  Structured extraction failed: {extraction_result['error_message']}"
-                    )
+            except Exception as exc:
+                logger.warning("Final structured output failed: %s", exc)
 
-            except Exception as e:
-                logger.error(f"❌ Error during structured extraction: {e}")
-                if self.config.logging.debug:
-                    logger.error(traceback.format_exc())
+        await _run_finalize_stage(
+            "telemetry-flush",
+            self._flush_final_telemetry(ev),
+            pre_cleanup_deadline,
+            cap=_FINALIZE_TELEMETRY_SECONDS,
+        )
 
         # Capture final screenshot and UI state (independent of trajectory persistence)
         vision_any = (
@@ -1068,52 +1134,126 @@ class MobileAgent(Workflow):
             or self._stream_screenshots
             or self.config.logging.save_trajectory != "none"
         ):
+            observation_deadline = min(
+                pre_cleanup_deadline,
+                time.monotonic() + _FINALIZE_OBSERVATION_SECONDS,
+            )
             try:
-                screenshot = await self.action_ctx.driver.screenshot()
-                if screenshot:
+                screenshot_operation = self.action_ctx.driver.screenshot()
+                completed, screenshot = await _run_finalize_stage(
+                    "screenshot",
+                    screenshot_operation,
+                    observation_deadline,
+                    cap=_FINALIZE_OBSERVATION_SECONDS,
+                )
+            except Exception as exc:
+                logger.warning("Failed to start final screenshot: %s", exc)
+                completed, screenshot = False, None
+            if completed and screenshot:
+                try:
                     ctx.write_event_to_stream(ScreenshotEvent(screenshot=screenshot))
-                    parent_span = trace.get_current_span()
                     record_langfuse_screenshot(
                         screenshot,
-                        parent_span=parent_span,
+                        parent_span=trace.get_current_span(),
                         screenshots_enabled=self.config.tracing.langfuse_screenshots,
                         vision_enabled=vision_any,
                     )
                     logger.debug("📸 Final screenshot captured")
-            except Exception as e:
-                logger.warning(f"Failed to capture final screenshot: {e}")
+                except Exception as exc:
+                    logger.warning("Failed to publish final screenshot: %s", exc)
 
             try:
-                ui_state = await self.state_provider.get_state()
-                ctx.write_event_to_stream(
-                    RecordUIStateEvent(ui_state=ui_state.elements)
+                final_state = getattr(
+                    self.state_provider,
+                    "get_final_state",
+                    self.state_provider.get_state,
                 )
-                logger.debug("📋 Final UI state captured")
-            except Exception as e:
-                logger.warning(f"Failed to capture final UI state: {e}")
+                completed, ui_state = await _run_finalize_stage(
+                    "ui-state",
+                    final_state(),
+                    observation_deadline,
+                    cap=_FINALIZE_OBSERVATION_SECONDS,
+                )
+            except Exception as exc:
+                logger.warning("Failed to start final UI state: %s", exc)
+                completed, ui_state = False, None
+            if completed and ui_state is not None:
+                try:
+                    ctx.write_event_to_stream(
+                        RecordUIStateEvent(ui_state=ui_state.elements)
+                    )
+                    logger.debug("📋 Final UI state captured")
+                except Exception as exc:
+                    logger.warning("Failed to publish final UI state: %s", exc)
 
         # Save trajectory to disk
-        if self.config.logging.save_trajectory != "none":
-            # Prefer rich action-level macro entries; fall back to raw driver logs.
-            if self.macro_recorder and self.macro_recorder.actions:
-                self.trajectory.macro = list(self.macro_recorder.actions)
-            elif isinstance(self.driver, RecordingDriver):
-                self.trajectory.macro = list(self.driver.log)
-
-            self.trajectory_writer.write_final(
-                self.trajectory, self.config.logging.trajectory_gifs
-            )
-            await self.trajectory_writer.stop()
-            logger.info(f"📁 Trajectory saved: {self.trajectory.trajectory_folder}")
+        if saves_trajectory:
+            trajectory_written = False
+            try:
+                # Prefer rich action-level macro entries; fall back to raw driver logs.
+                if self.macro_recorder and self.macro_recorder.actions:
+                    self.trajectory.macro = list(self.macro_recorder.actions)
+                elif isinstance(self.driver, RecordingDriver):
+                    self.trajectory.macro = list(self.driver.log)
+                self.trajectory_writer.write_final(
+                    self.trajectory, self.config.logging.trajectory_gifs
+                )
+                trajectory_written = True
+            except Exception as exc:
+                logger.warning("Final trajectory persistence failed: %s", exc)
+            finally:
+                try:
+                    mcp_reserve = (
+                        min(
+                            _FINALIZE_MCP_SECONDS,
+                            max(0.0, deadline - time.monotonic()) / 2,
+                        )
+                        if has_mcp
+                        else 0.0
+                    )
+                    completed, _ = await _run_finalize_stage(
+                        "trajectory-stop",
+                        self.trajectory_writer.stop(),
+                        deadline - mcp_reserve,
+                        cap=_FINALIZE_TRAJECTORY_SECONDS,
+                    )
+                    if trajectory_written and completed:
+                        logger.info(
+                            f"📁 Trajectory saved: {self.trajectory.trajectory_folder}"
+                        )
+                except Exception as exc:
+                    logger.warning("Final trajectory shutdown failed: %s", exc)
 
         # Cleanup MCP connections
-        if self.mcp_manager:
+        if has_mcp:
             try:
-                await self.mcp_manager.disconnect_all()
-            except Exception as e:
-                logger.warning(f"MCP cleanup error: {e}")
+                await _run_finalize_stage(
+                    "mcp-disconnect",
+                    self.mcp_manager.disconnect_all(),
+                    deadline,
+                    cap=_FINALIZE_MCP_SECONDS,
+                )
+            except Exception as exc:
+                logger.warning("MCP cleanup setup failed: %s", exc)
 
         return result
+
+    async def _flush_final_telemetry(self, ev: FinalizeEvent) -> None:
+        try:
+            capture(
+                MobileAgentFinalizeEvent(
+                    success=ev.success,
+                    reason=ev.reason,
+                    steps=self.shared_state.step_number,
+                    unique_packages_count=len(self.shared_state.visited_packages),
+                    unique_activities_count=len(self.shared_state.visited_activities),
+                ),
+                self.user_id,
+                config_enabled=self.shared_state.telemetry_config_enabled,
+            )
+        except Exception as exc:
+            logger.warning("Final telemetry capture failed: %s", exc)
+        await flush(config_enabled=self.shared_state.telemetry_config_enabled)
 
     # ========================================================================
     # Event streaming

--- a/mobilerun/agent/trajectory/writer.py
+++ b/mobilerun/agent/trajectory/writer.py
@@ -198,21 +198,28 @@ class WriterWorker:
         if not self.running:
             return
 
+        drain_task = asyncio.create_task(self.queue.join())
         try:
-            await asyncio.wait_for(self.queue.join(), timeout=timeout)
-        except asyncio.TimeoutError:
-            logger.warning(
-                f"Writer timeout after {timeout}s, {self.queue.qsize()} jobs remaining"
-            )
+            done, _ = await asyncio.wait({drain_task}, timeout=timeout)
+            if not done:
+                logger.warning(
+                    f"Writer timeout after {timeout}s, {self.queue.qsize()} jobs remaining"
+                )
+        finally:
+            if not drain_task.done():
+                drain_task.cancel()
+                drain_task.add_done_callback(self._consume_worker_result)
+            self.running = False
+            if self.worker_task and not self.worker_task.done():
+                self.worker_task.cancel()
+                self.worker_task.add_done_callback(self._consume_worker_result)
 
-        self.running = False
-
-        if self.worker_task:
-            self.worker_task.cancel()
-            try:
-                await self.worker_task
-            except asyncio.CancelledError:
-                pass
+    @staticmethod
+    def _consume_worker_result(task: asyncio.Task) -> None:
+        try:
+            task.result()
+        except (asyncio.CancelledError, Exception):
+            pass
 
     async def _work_loop(self) -> None:
         while self.running:

--- a/mobilerun/telemetry/phoenix.py
+++ b/mobilerun/telemetry/phoenix.py
@@ -124,7 +124,7 @@ def clean_span(span_name: str):
                 )
                 try:
                     result = await func(*args, **kwargs)
-                except Exception as e:
+                except BaseException as e:
                     dispatcher.span_drop(
                         id_=span_id, bound_args=bound_args, instance=instance, err=e
                     )

--- a/mobilerun/tools/ui/provider.py
+++ b/mobilerun/tools/ui/provider.py
@@ -154,6 +154,10 @@ class StateProvider:
     async def get_state(self) -> UIState:
         raise NotImplementedError
 
+    async def get_final_state(self) -> UIState:
+        """Read the final observation; subclasses may make this narrower."""
+        return await self.get_state()
+
 
 def should_resize_model_screenshot(state_provider: Any) -> bool:
     """True when screenshots attached to LLM messages must be resized (with
@@ -292,6 +296,13 @@ class AndroidStateProvider(StateProvider):
             fetch=self.driver.get_ui_tree,
             recovery=self._recover_portal,
         )
+        return self._state_from_data(combined_data)
+
+    async def get_final_state(self) -> UIState:
+        """Finalization must not restart accessibility after a failed read."""
+        return self._state_from_data(await self.driver.get_ui_tree())
+
+    def _state_from_data(self, combined_data: dict) -> UIState:
 
         device_context = combined_data["device_context"]
         screen_bounds = device_context.get("screen_bounds", {})

--- a/tests/test_bounded_finalization.py
+++ b/tests/test_bounded_finalization.py
@@ -1,0 +1,453 @@
+import asyncio
+import time
+from types import SimpleNamespace
+
+import pytest
+from llama_index.core.workflow import StopEvent
+from pydantic import BaseModel
+
+import mobilerun.agent.droid.droid_agent as module
+import mobilerun.agent.oneflows.structured_output_agent as structured_module
+import mobilerun.tools.ui.provider as provider_module
+from mobilerun.agent.common.events import ScreenshotEvent
+from mobilerun.agent.droid.droid_agent import MobileAgent
+from mobilerun.agent.droid.events import FinalizeEvent
+from mobilerun.agent.oneflows.structured_output_agent import StructuredOutputAgent
+from mobilerun.tools.ui.provider import AndroidStateProvider
+
+
+async def _empty_state():
+    return SimpleNamespace(elements=[])
+
+
+async def _nothing():
+    return None
+
+
+def _agent(monkeypatch, screenshot=_nothing, state=_empty_state, *, deadline=None):
+    monkeypatch.setattr(module, "capture", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        module, "record_langfuse_screenshot", lambda *args, **kwargs: None
+    )
+
+    async def flush(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(module, "flush", flush)
+    agent = object.__new__(MobileAgent)
+    agent.shared_state = SimpleNamespace(
+        workflow_completed=False,
+        step_number=2,
+        visited_packages=set(),
+        visited_activities=set(),
+        telemetry_config_enabled=False,
+    )
+    agent.user_id = None
+    agent.output_model = None
+    agent.config = SimpleNamespace(
+        agent=SimpleNamespace(
+            manager=SimpleNamespace(vision=True),
+            executor=SimpleNamespace(vision=False),
+            fast_agent=SimpleNamespace(vision=False),
+        ),
+        logging=SimpleNamespace(
+            save_trajectory="none", debug=False, trajectory_gifs=False
+        ),
+        tracing=SimpleNamespace(langfuse_screenshots=False),
+    )
+    agent._stream_screenshots = False
+    agent.action_ctx = SimpleNamespace(driver=SimpleNamespace(screenshot=screenshot))
+    agent.state_provider = SimpleNamespace(get_state=state)
+    agent.macro_recorder = None
+    agent.mcp_manager = None
+    agent._workflow_deadline = deadline
+    agent.timeout = 60
+    agent.structured_output_llm = object()
+    return agent
+
+
+async def _finalize(agent, *, success=True, reason="answer", events=None):
+    events = [] if events is None else events
+    result = await agent.finalize(
+        SimpleNamespace(write_event_to_stream=events.append),
+        FinalizeEvent(success=success, reason=reason),
+    )
+    return result, events
+
+
+def _enable_trajectory(agent, stop=_nothing, write_final=lambda *args: None):
+    agent.config.logging.save_trajectory = "all"
+    agent.trajectory = SimpleNamespace(trajectory_folder="unused", macro=[])
+    agent.macro_recorder = None
+    agent.driver = None
+    agent.trajectory_writer = SimpleNamespace(write_final=write_final, stop=stop)
+
+
+def _structured(result=None):
+    class Structured:
+        def __init__(self, **kwargs):
+            pass
+
+        async def extract_structured_output(self, ctx, event):
+            return SimpleNamespace(
+                result={"success": True, "structured_output": result}
+            )
+
+    return Structured
+
+
+def test_resistant_final_observation_returns_before_late_task_and_publishes_nothing(
+    monkeypatch,
+):
+    async def run():
+        entered, released, completed = asyncio.Event(), asyncio.Event(), asyncio.Event()
+
+        async def screenshot():
+            entered.set()
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                await released.wait()
+                completed.set()
+                return b"late"
+
+        monkeypatch.setattr(module, "_FINALIZE_BUDGET_SECONDS", 0.03)
+        events = []
+        task = asyncio.create_task(
+            _finalize(_agent(monkeypatch, screenshot), events=events)
+        )
+        await asyncio.wait_for(entered.wait(), timeout=1)
+        result, _ = await asyncio.wait_for(task, timeout=0.5)
+        assert result.success is True
+        assert not completed.is_set()
+        assert not any(isinstance(event, ScreenshotEvent) for event in events)
+        before_release = list(events)
+        released.set()
+        await asyncio.wait_for(completed.wait(), timeout=1)
+        await asyncio.sleep(0)
+        assert events == before_release
+
+    asyncio.run(run())
+
+
+def test_expired_workflow_deadline_preserves_false_result_without_optional_work(
+    monkeypatch,
+):
+    async def run():
+        called = False
+
+        async def screenshot():
+            nonlocal called
+            called = True
+            return b"png"
+
+        agent = _agent(monkeypatch, screenshot, deadline=time.monotonic())
+        result, _ = await _finalize(agent, success=False, reason="no")
+        assert (result.success, result.reason, called) == (False, "no", False)
+
+    asyncio.run(run())
+
+
+def test_external_cancellation_cancels_owned_stage(monkeypatch):
+    async def run():
+        started, cancelled = asyncio.Event(), asyncio.Event()
+
+        async def screenshot():
+            started.set()
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+        task = asyncio.create_task(_finalize(_agent(monkeypatch, screenshot)))
+        await asyncio.wait_for(started.wait(), timeout=1)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        await asyncio.wait_for(cancelled.wait(), timeout=1)
+
+    asyncio.run(run())
+
+
+@pytest.mark.parametrize("success", [True, False])
+def test_finalize_keeps_normal_structured_output_and_artifact_events(
+    monkeypatch, success
+):
+    async def screenshot():
+        return b"png"
+
+    async def state():
+        return SimpleNamespace(elements=[{"text": "element"}])
+
+    agent = _agent(monkeypatch, screenshot, state)
+    agent.output_model = object()
+    monkeypatch.setattr(module, "StructuredOutputAgent", _structured({"parsed": True}))
+    result, events = asyncio.run(_finalize(agent, success=success))
+    assert (result.success, result.reason) == (success, "answer")
+    assert result.structured_output == {"parsed": True}
+    assert isinstance(events[0], FinalizeEvent)
+    assert isinstance(events[1], ScreenshotEvent)
+    assert events[1].screenshot == b"png"
+    assert events[2].ui_state == [{"text": "element"}]
+
+
+@pytest.mark.parametrize("stage", ["capture", "flush", "screenshot", "state"])
+def test_epilog_errors_are_isolated_and_preserve_false_result(monkeypatch, stage):
+    async def run():
+        entered = []
+
+        async def screenshot():
+            entered.append("screenshot")
+            if stage == "screenshot":
+                raise RuntimeError(stage)
+
+        async def state():
+            entered.append("state")
+            if stage == "state":
+                raise RuntimeError(stage)
+            return SimpleNamespace(elements=[])
+
+        agent = _agent(monkeypatch, screenshot, state)
+        if stage == "capture":
+            monkeypatch.setattr(
+                module,
+                "capture",
+                lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError(stage)),
+            )
+        if stage == "flush":
+
+            async def flush(**kwargs):
+                entered.append("flush")
+                raise RuntimeError(stage)
+
+            monkeypatch.setattr(module, "flush", flush)
+        result, _ = await _finalize(agent, success=False, reason="no")
+        assert (result.success, result.reason) == (False, "no")
+        assert stage in entered or stage == "capture"
+
+    asyncio.run(run())
+
+
+def test_trajectory_write_error_still_stops_and_disconnects_without_saved_log(
+    monkeypatch,
+):
+    async def run():
+        stopped, disconnected, messages = False, False, []
+
+        async def stop():
+            nonlocal stopped
+            stopped = True
+
+        async def disconnect():
+            nonlocal disconnected
+            disconnected = True
+
+        def write_final(*args):
+            raise RuntimeError("disk")
+
+        agent = _agent(monkeypatch)
+        _enable_trajectory(agent, stop, write_final)
+        agent.mcp_manager = SimpleNamespace(disconnect_all=disconnect)
+        monkeypatch.setattr(module.logger, "info", messages.append)
+        await _finalize(agent)
+        assert stopped and disconnected
+        assert not any("Trajectory saved" in str(message) for message in messages)
+
+    asyncio.run(run())
+
+
+def test_android_final_observation_is_single_read_and_normal_read_retries(monkeypatch):
+    async def run():
+        final_provider = object.__new__(AndroidStateProvider)
+        final_calls = []
+
+        class Driver:
+            async def get_ui_tree(self):
+                final_calls.append("read")
+                return {"raw": True}
+
+        final_provider.driver = Driver()
+        final_provider._state_from_data = lambda value: value
+
+        async def no_retry(*args, **kwargs):
+            raise AssertionError("final observation must not retry")
+
+        monkeypatch.setattr(provider_module, "fetch_state_with_retry", no_retry)
+        assert await final_provider.get_final_state() == {"raw": True}
+        assert final_calls == ["read"]
+
+        normal_provider = object.__new__(AndroidStateProvider)
+        normal_provider.driver = SimpleNamespace(get_ui_tree=object())
+        normal_provider._state_from_data = lambda value: value
+        retried = False
+
+        async def retry(*, fetch, recovery):
+            nonlocal retried
+            retried = True
+            assert fetch is normal_provider.driver.get_ui_tree
+            assert recovery.__self__ is normal_provider
+            return {"retried": True}
+
+        monkeypatch.setattr(provider_module, "fetch_state_with_retry", retry)
+        assert await normal_provider.get_state() == {"retried": True}
+        assert retried
+
+    asyncio.run(run())
+
+
+class _StructuredOutput(BaseModel):
+    value: str
+
+
+@pytest.mark.parametrize("raises", [False, True])
+def test_direct_structured_extraction_matches_real_workflow(monkeypatch, raises):
+    async def inference(*args, **kwargs):
+        if raises:
+            raise RuntimeError("inference failed")
+        return _StructuredOutput(value="parsed")
+
+    monkeypatch.setattr(
+        structured_module, "astructured_predict_with_retries", inference
+    )
+
+    async def run():
+        reference = StructuredOutputAgent(
+            llm=object(), pydantic_model=_StructuredOutput, answer_text="answer"
+        )
+        handler = reference.run()
+        reference_events = [
+            event
+            async for event in handler.stream_events()
+            if not isinstance(event, StopEvent)
+        ]
+        reference_result = await handler
+        agent = _agent(monkeypatch)
+        agent.output_model = _StructuredOutput
+        agent.config.agent.manager.vision = False
+        result, events = await _finalize(agent)
+        assert events[1:] == reference_events
+        assert result.structured_output == reference_result["structured_output"]
+        assert (result.success, result.reason) == (True, "answer")
+
+    asyncio.run(run())
+
+
+@pytest.mark.parametrize(
+    "leading_stage", ["structured", "flush", "screenshot", "state"]
+)
+def test_hung_epilog_stages_share_one_budget_and_keep_cleanup(
+    monkeypatch, leading_stage
+):
+    async def run():
+        entered = []
+
+        async def stall(name):
+            entered.append(name)
+            await asyncio.Future()
+
+        class Structured:
+            def __init__(self, **kwargs):
+                pass
+
+            async def extract_structured_output(self, ctx, event):
+                if leading_stage == "structured":
+                    await stall("structured")
+                return SimpleNamespace(
+                    result={"success": True, "structured_output": None}
+                )
+
+        async def screenshot():
+            if leading_stage == "screenshot":
+                await stall("screenshot")
+
+        async def state():
+            if leading_stage == "state":
+                await stall("state")
+            return SimpleNamespace(elements=[])
+
+        async def flush(**kwargs):
+            if leading_stage == "flush":
+                await stall("flush")
+
+        monkeypatch.setattr(module, "_FINALIZE_BUDGET_SECONDS", 0.12)
+        monkeypatch.setattr(module, "_FINALIZE_TRAJECTORY_SECONDS", 0.04)
+        monkeypatch.setattr(module, "_FINALIZE_MCP_SECONDS", 0.02)
+        monkeypatch.setattr(module, "StructuredOutputAgent", Structured)
+        agent = _agent(monkeypatch, screenshot, state)
+        monkeypatch.setattr(module, "flush", flush)
+        agent.output_model = object()
+        agent.config.agent.manager.vision = False
+        _enable_trajectory(agent, stop=lambda: stall("trajectory"))
+        agent.mcp_manager = SimpleNamespace(disconnect_all=lambda: stall("mcp"))
+        started = time.monotonic()
+        result, _ = await _finalize(agent)
+        assert result.success is True
+        assert time.monotonic() - started < 0.3
+        assert {leading_stage, "trajectory", "mcp"} <= set(entered)
+
+    asyncio.run(run())
+
+
+def test_finalize_stage_policy_uses_named_caps_and_no_phantom_cleanup(monkeypatch):
+    async def run():
+        calls = {}
+        original = module._run_finalize_stage
+
+        async def record(name, awaitable, deadline, cap):
+            calls[name] = (deadline, cap)
+            return await original(name, awaitable, deadline, cap)
+
+        monkeypatch.setattr(module, "_run_finalize_stage", record)
+        monkeypatch.setattr(module, "StructuredOutputAgent", _structured())
+        agent = _agent(monkeypatch)
+        agent.output_model = object()
+        agent.config.agent.manager.vision = False
+        _enable_trajectory(agent)
+        agent.mcp_manager = SimpleNamespace(disconnect_all=_nothing)
+        await _finalize(agent)
+        assert calls["structured-output"][1] == module._FINALIZE_BUDGET_SECONDS
+        assert calls["telemetry-flush"][1] == module._FINALIZE_TELEMETRY_SECONDS
+        assert calls["trajectory-stop"][1] == module._FINALIZE_TRAJECTORY_SECONDS
+        assert calls["mcp-disconnect"][1] == module._FINALIZE_MCP_SECONDS
+
+        calls.clear()
+        monkeypatch.setattr(module, "_FINALIZE_BUDGET_SECONDS", 0.2)
+        started = time.monotonic()
+        bare = _agent(monkeypatch)
+        bare.output_model = object()
+        bare.config.agent.manager.vision = False
+        await _finalize(bare)
+        assert calls["structured-output"][0] - started > 0.18
+
+    asyncio.run(run())
+
+
+@pytest.mark.parametrize("available", [32.9, 33.1])
+def test_cleanup_reserve_is_continuous_at_demand_threshold(monkeypatch, available):
+    async def run():
+        structured_deadline = None
+        original = module._run_finalize_stage
+
+        async def record(name, awaitable, deadline, cap):
+            nonlocal structured_deadline
+            if name == "structured-output":
+                structured_deadline = deadline
+            return await original(name, awaitable, deadline, cap)
+
+        monkeypatch.setattr(module, "_run_finalize_stage", record)
+        monkeypatch.setattr(module, "StructuredOutputAgent", _structured())
+        started = time.monotonic()
+        agent = _agent(
+            monkeypatch,
+            deadline=started + available + module._FINALIZE_SCHEDULING_RESERVE_SECONDS,
+        )
+        agent.output_model = object()
+        agent.config.agent.manager.vision = False
+        _enable_trajectory(agent)
+        agent.mcp_manager = SimpleNamespace(disconnect_all=_nothing)
+        await _finalize(agent)
+        assert structured_deadline is not None
+        assert structured_deadline - started > available * 0.45
+
+    asyncio.run(run())

--- a/tests/test_bounded_finalization.py
+++ b/tests/test_bounded_finalization.py
@@ -4,10 +4,14 @@ from types import SimpleNamespace
 
 import pytest
 from llama_index.core.workflow import StopEvent
+from llama_index_instrumentation.span import active_span_id
+from llama_index_instrumentation.span.base import BaseSpan
+from llama_index_instrumentation.span_handlers.base import BaseSpanHandler
 from pydantic import BaseModel
 
 import mobilerun.agent.droid.droid_agent as module
 import mobilerun.agent.oneflows.structured_output_agent as structured_module
+import mobilerun.telemetry.phoenix as phoenix_module
 import mobilerun.tools.ui.provider as provider_module
 from mobilerun.agent.common.events import ScreenshotEvent
 from mobilerun.agent.droid.droid_agent import MobileAgent
@@ -94,6 +98,180 @@ def _structured(result=None):
             )
 
     return Structured
+
+
+def _failed_structured(error_message):
+    class Structured:
+        def __init__(self, **kwargs):
+            pass
+
+        async def extract_structured_output(self, ctx, event):
+            return SimpleNamespace(
+                result={
+                    "success": False,
+                    "structured_output": None,
+                    "error_message": error_message,
+                }
+            )
+
+    return Structured
+
+
+class _RecordedSpan(BaseSpan):
+    arguments: dict
+    result: object = None
+    error: BaseException | None = None
+
+
+class _RecordingSpanHandler(BaseSpanHandler[_RecordedSpan]):
+    def new_span(self, id_, bound_args, instance=None, parent_span_id=None, tags=None):
+        return _RecordedSpan(
+            id_=id_,
+            parent_id=parent_span_id,
+            tags=tags or {},
+            arguments=dict(bound_args.arguments),
+        )
+
+    def prepare_to_exit_span(self, id_, bound_args, instance=None, result=None):
+        span = self.open_spans[id_]
+        span.result = result
+        self.completed_spans.append(span)
+        return span
+
+    def prepare_to_drop_span(self, id_, bound_args, instance=None, err=None):
+        span = self.open_spans[id_]
+        span.error = err
+        self.dropped_spans.append(span)
+        return span
+
+
+@pytest.fixture
+def span_recorder():
+    handler = _RecordingSpanHandler()
+    phoenix_module.dispatcher.add_span_handler(handler)
+    try:
+        yield handler
+    finally:
+        phoenix_module.dispatcher.span_handlers.remove(handler)
+
+
+def test_direct_structured_extraction_restores_observations_and_parentage(
+    monkeypatch, span_recorder
+):
+    async def run():
+        agent = _agent(monkeypatch)
+        agent.output_model = object()
+        agent.config.agent.manager.vision = False
+        monkeypatch.setattr(
+            module, "StructuredOutputAgent", _structured({"parsed": True})
+        )
+
+        token = active_span_id.set("MobileAgent.finalize-parent")
+        try:
+            result, _ = await _finalize(agent)
+        finally:
+            active_span_id.reset(token)
+
+        assert result.structured_output == {"parsed": True}
+        assert not span_recorder.open_spans
+        assert len(span_recorder.completed_spans) == 2
+        run_span = next(
+            span
+            for span in span_recorder.completed_spans
+            if span.id_.startswith("StructuredOutputAgent.run-")
+        )
+        extract_span = next(
+            span
+            for span in span_recorder.completed_spans
+            if span.id_.startswith("StructuredOutputAgent.extract_structured_output-")
+        )
+        assert run_span.parent_id == "MobileAgent.finalize-parent"
+        assert extract_span.parent_id == run_span.id_
+        assert run_span.arguments == extract_span.arguments == {}
+
+        for span in span_recorder.completed_spans:
+            assert span.result.result == {
+                "success": True,
+                "structured_output": {"parsed": True},
+            }
+
+    asyncio.run(run())
+
+
+def test_structured_extraction_timeout_drops_observations(monkeypatch, span_recorder):
+    async def run():
+        entered = asyncio.Event()
+
+        class Structured:
+            def __init__(self, **kwargs):
+                pass
+
+            async def extract_structured_output(self, ctx, event):
+                entered.set()
+                await asyncio.Future()
+
+        monkeypatch.setattr(module, "_FINALIZE_BUDGET_SECONDS", 0.03)
+        monkeypatch.setattr(module, "StructuredOutputAgent", Structured)
+        agent = _agent(monkeypatch)
+        agent.output_model = object()
+        agent.config.agent.manager.vision = False
+
+        token = active_span_id.set("MobileAgent.finalize-parent")
+        try:
+            result, _ = await _finalize(agent)
+            assert entered.is_set()
+            abandoned = list(module._ABANDONED_FINALIZE_TASKS)
+            if abandoned:
+                await asyncio.wait_for(
+                    asyncio.gather(*abandoned, return_exceptions=True), timeout=1
+                )
+            await asyncio.sleep(0)
+        finally:
+            active_span_id.reset(token)
+
+        assert result.structured_output is None
+        assert not module._ABANDONED_FINALIZE_TASKS
+        assert not span_recorder.open_spans
+        assert not span_recorder.completed_spans
+        assert len(span_recorder.dropped_spans) == 2
+        assert all(
+            isinstance(span.error, asyncio.CancelledError)
+            for span in span_recorder.dropped_spans
+        )
+        assert any(
+            span.id_.startswith("StructuredOutputAgent.run-")
+            for span in span_recorder.dropped_spans
+        )
+        assert any(
+            span.id_.startswith("StructuredOutputAgent.extract_structured_output-")
+            for span in span_recorder.dropped_spans
+        )
+
+    asyncio.run(run())
+
+
+def test_direct_structured_extraction_records_error_result(monkeypatch, span_recorder):
+    async def run():
+        agent = _agent(monkeypatch)
+        agent.output_model = object()
+        agent.config.agent.manager.vision = False
+        monkeypatch.setattr(
+            module, "StructuredOutputAgent", _failed_structured("invalid response")
+        )
+
+        result, _ = await _finalize(agent)
+
+        assert result.structured_output is None
+        assert not span_recorder.open_spans
+        assert len(span_recorder.completed_spans) == 2
+        for span in span_recorder.completed_spans:
+            assert span.result.result == {
+                "success": False,
+                "structured_output": None,
+                "error_message": "invalid response",
+            }
+
+    asyncio.run(run())
 
 
 def test_resistant_final_observation_returns_before_late_task_and_publishes_nothing(

--- a/tests/test_bounded_finalization.py
+++ b/tests/test_bounded_finalization.py
@@ -1,4 +1,6 @@
 import asyncio
+import os
+import sys
 import time
 from types import SimpleNamespace
 
@@ -17,6 +19,7 @@ from mobilerun.agent.common.events import ScreenshotEvent
 from mobilerun.agent.droid.droid_agent import MobileAgent
 from mobilerun.agent.droid.events import FinalizeEvent
 from mobilerun.agent.oneflows.structured_output_agent import StructuredOutputAgent
+from mobilerun.agent.trajectory import TrajectoryWriter
 from mobilerun.tools.ui.provider import AndroidStateProvider
 
 
@@ -26,6 +29,17 @@ async def _empty_state():
 
 async def _nothing():
     return None
+
+
+class _Store:
+    def __init__(self, deadline):
+        self.deadline = deadline
+
+    async def get(self, key, default=None):
+        return self.deadline
+
+    async def set(self, key, value):
+        self.deadline = value
 
 
 def _agent(monkeypatch, screenshot=_nothing, state=_empty_state, *, deadline=None):
@@ -64,7 +78,7 @@ def _agent(monkeypatch, screenshot=_nothing, state=_empty_state, *, deadline=Non
     agent.state_provider = SimpleNamespace(get_state=state)
     agent.macro_recorder = None
     agent.mcp_manager = None
-    agent._workflow_deadline = deadline
+    agent._test_workflow_deadline = deadline
     agent.timeout = 60
     agent.structured_output_llm = object()
     return agent
@@ -73,7 +87,10 @@ def _agent(monkeypatch, screenshot=_nothing, state=_empty_state, *, deadline=Non
 async def _finalize(agent, *, success=True, reason="answer", events=None):
     events = [] if events is None else events
     result = await agent.finalize(
-        SimpleNamespace(write_event_to_stream=events.append),
+        SimpleNamespace(
+            write_event_to_stream=events.append,
+            store=_Store(agent._test_workflow_deadline),
+        ),
         FinalizeEvent(success=success, reason=reason),
     )
     return result, events
@@ -572,9 +589,9 @@ def test_finalize_stage_policy_uses_named_caps_and_no_phantom_cleanup(monkeypatc
         calls = {}
         original = module._run_finalize_stage
 
-        async def record(name, awaitable, deadline, cap):
-            calls[name] = (deadline, cap)
-            return await original(name, awaitable, deadline, cap)
+        async def record(name, awaitable, deadline, cap, **kwargs):
+            calls[name] = (deadline, cap, kwargs.get("continue_in_background", False))
+            return await original(name, awaitable, deadline, cap, **kwargs)
 
         monkeypatch.setattr(module, "_run_finalize_stage", record)
         monkeypatch.setattr(module, "StructuredOutputAgent", _structured())
@@ -588,6 +605,8 @@ def test_finalize_stage_policy_uses_named_caps_and_no_phantom_cleanup(monkeypatc
         assert calls["telemetry-flush"][1] == module._FINALIZE_TELEMETRY_SECONDS
         assert calls["trajectory-stop"][1] == module._FINALIZE_TRAJECTORY_SECONDS
         assert calls["mcp-disconnect"][1] == module._FINALIZE_MCP_SECONDS
+        assert calls["trajectory-stop"][2] is True
+        assert calls["mcp-disconnect"][2] is True
 
         calls.clear()
         monkeypatch.setattr(module, "_FINALIZE_BUDGET_SECONDS", 0.2)
@@ -607,11 +626,11 @@ def test_cleanup_reserve_is_continuous_at_demand_threshold(monkeypatch, availabl
         structured_deadline = None
         original = module._run_finalize_stage
 
-        async def record(name, awaitable, deadline, cap):
+        async def record(name, awaitable, deadline, cap, **kwargs):
             nonlocal structured_deadline
             if name == "structured-output":
                 structured_deadline = deadline
-            return await original(name, awaitable, deadline, cap)
+            return await original(name, awaitable, deadline, cap, **kwargs)
 
         monkeypatch.setattr(module, "_run_finalize_stage", record)
         monkeypatch.setattr(module, "StructuredOutputAgent", _structured())
@@ -627,5 +646,90 @@ def test_cleanup_reserve_is_continuous_at_demand_threshold(monkeypatch, availabl
         await _finalize(agent)
         assert structured_deadline is not None
         assert structured_deadline - started > available * 0.45
+
+    asyncio.run(run())
+
+
+def _process_exists(pid):
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+def test_expired_budget_still_closes_real_writer_and_mcp(monkeypatch, tmp_path):
+    server_script = tmp_path / "finalization_mcp_server.py"
+    server_script.write_text("""
+import os
+
+from mcp.server.fastmcp import FastMCP
+
+server = FastMCP("finalization-cleanup-test")
+
+
+@server.tool()
+def pid() -> str:
+    return str(os.getpid())
+
+
+if __name__ == "__main__":
+    server.run(transport="stdio")
+""".lstrip())
+
+    async def run():
+        writer = TrajectoryWriter()
+        await writer.start()
+        process = await asyncio.create_subprocess_exec(
+            sys.executable,
+            str(server_script),
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        server_pid = process.pid
+
+        async def disconnect_all():
+            assert process.stdin is not None
+            process.stdin.close()
+            await process.wait()
+
+        manager = SimpleNamespace(
+            connected_servers=["fixture"], disconnect_all=disconnect_all
+        )
+        assert writer.worker.running
+        assert manager.connected_servers == ["fixture"]
+        assert _process_exists(server_pid)
+
+        agent = _agent(monkeypatch, deadline=time.monotonic() - 1)
+        agent.config.agent.manager.vision = False
+        agent.config.logging.save_trajectory = "all"
+        agent.trajectory = SimpleNamespace(trajectory_folder="unused", macro=[])
+        agent.driver = None
+        agent.trajectory_writer = writer
+        monkeypatch.setattr(writer, "write_final", lambda *args: None)
+        agent.mcp_manager = manager
+
+        try:
+            result, _ = await _finalize(agent)
+            background_cleanup = list(module._ABANDONED_FINALIZE_TASKS)
+            if background_cleanup:
+                await asyncio.wait_for(
+                    asyncio.gather(*background_cleanup, return_exceptions=True),
+                    timeout=5,
+                )
+            await asyncio.sleep(0)
+
+            process_deadline = time.monotonic() + 2
+            while _process_exists(server_pid) and time.monotonic() < process_deadline:
+                await asyncio.sleep(0.01)
+
+            assert result.success is True
+            assert not writer.worker.running
+            assert not _process_exists(server_pid)
+        finally:
+            await writer.stop(timeout=0.1)
+            if process.returncode is None:
+                await disconnect_all()
 
     asyncio.run(run())

--- a/tests/test_finalization_budget.py
+++ b/tests/test_finalization_budget.py
@@ -1,0 +1,38 @@
+import asyncio
+import time
+
+from mobilerun.agent.droid.droid_agent import _run_finalize_stage
+from mobilerun.agent.trajectory.writer import WriterWorker
+
+
+def test_finalize_stage_drops_a_self_cancelled_child() -> None:
+    async def self_cancel() -> None:
+        raise asyncio.CancelledError()
+
+    async def run() -> None:
+        completed, result = await _run_finalize_stage(
+            "self-cancel", self_cancel(), time.monotonic() + 1, 1
+        )
+        assert (completed, result) == (False, None)
+
+    asyncio.run(run())
+
+
+def test_writer_stop_cancels_worker_when_stop_is_cancelled() -> None:
+    async def run() -> None:
+        worker = WriterWorker()
+        worker.running = True
+        worker.worker_task = asyncio.create_task(asyncio.sleep(60))
+        worker.queue.put_nowait(object())
+        stop_task = asyncio.create_task(worker.stop())
+        await asyncio.sleep(0)
+        stop_task.cancel()
+        try:
+            await stop_task
+        except asyncio.CancelledError:
+            pass
+        await asyncio.sleep(0)
+        assert not worker.running
+        assert worker.worker_task.cancelled()
+
+    asyncio.run(run())

--- a/tests/test_finalization_workflow.py
+++ b/tests/test_finalization_workflow.py
@@ -20,19 +20,28 @@ from mobilerun.agent.droid.events import (
 class FinishingAgent(MobileAgent):
     """Replace device/LLM setup, retaining MobileAgent.run and finalize."""
 
-    def __init__(self, timeout):
-        Workflow.__init__(self, timeout=timeout)
+    def __init__(self, timeout, num_concurrent_runs=None):
+        Workflow.__init__(
+            self, timeout=timeout, num_concurrent_runs=num_concurrent_runs
+        )
         self.timeout = timeout
 
     @step
     async def start_handler(
         self, ctx: Context, ev: StartEvent
     ) -> FastAgentExecuteEvent | ManagerInputEvent | FinalizeEvent:
+        await self._initialize_workflow_deadline(ctx)
+        started = ev.get("started", default=None)
+        if started is not None:
+            started.set()
         await asyncio.sleep(ev.delay)
-        return FinalizeEvent(success=ev.success, reason="decided")
+        return FinalizeEvent(
+            success=ev.success,
+            reason=ev.get("reason", default="decided"),
+        )
 
 
-def _agent(monkeypatch, timeout, screenshot):
+def _agent(monkeypatch, timeout, screenshot, *, num_concurrent_runs=None):
     async def flush(**kwargs):
         pass
 
@@ -42,7 +51,7 @@ def _agent(monkeypatch, timeout, screenshot):
     monkeypatch.setattr(module, "capture", lambda *a, **kw: None)
     monkeypatch.setattr(module, "flush", flush)
     monkeypatch.setattr(module, "_FINALIZE_SCHEDULING_RESERVE_SECONDS", 0.05)
-    agent = FinishingAgent(timeout)
+    agent = FinishingAgent(timeout, num_concurrent_runs=num_concurrent_runs)
     agent.shared_state = SimpleNamespace(
         workflow_completed=False,
         step_number=1,
@@ -62,6 +71,7 @@ def _agent(monkeypatch, timeout, screenshot):
         tracing=SimpleNamespace(langfuse_screenshots=False),
     )
     agent._stream_screenshots = False
+    agent.structured_output_llm = object()
     agent.action_ctx = SimpleNamespace(driver=SimpleNamespace(screenshot=screenshot))
     agent.state_provider = SimpleNamespace(get_state=state)
     agent.mcp_manager = None
@@ -156,5 +166,85 @@ def test_user_cancellation_during_epilog_still_cancels_workflow(monkeypatch):
         with pytest.raises(WorkflowCancelledByUser):
             await handler
         await asyncio.wait_for(cancelled.wait(), 1)
+
+    asyncio.run(run())
+
+
+def test_serialized_runs_each_receive_a_runtime_scoped_finalization_budget(monkeypatch):
+    async def run():
+        extracted = []
+
+        class Structured:
+            def __init__(self, *, answer_text, **kwargs):
+                self.answer_text = answer_text
+
+            async def extract_structured_output(self, ctx, event):
+                await asyncio.sleep(0.2)
+                extracted.append(self.answer_text)
+                return SimpleNamespace(
+                    result={
+                        "success": True,
+                        "structured_output": {"run": self.answer_text},
+                    }
+                )
+
+        monkeypatch.setattr(module, "StructuredOutputAgent", Structured)
+        agent = _agent(
+            monkeypatch,
+            timeout=0.6,
+            screenshot=lambda: None,
+            num_concurrent_runs=1,
+        )
+        agent.output_model = object()
+        agent.config.agent.manager.vision = False
+        first_started = asyncio.Event()
+        first = agent.run(
+            delay=0.3,
+            success=True,
+            reason="first",
+            started=first_started,
+        )
+        await asyncio.wait_for(first_started.wait(), timeout=1)
+        await asyncio.sleep(0.05)
+        second = agent.run(delay=0, success=True, reason="second")
+
+        first_result = await first
+        second_result = await second
+
+        assert first_result.structured_output == {"run": "first"}
+        assert second_result.structured_output == {"run": "second"}
+        assert extracted == ["first", "second"]
+
+    asyncio.run(run())
+
+
+def test_second_run_cannot_extend_active_run_deadline(monkeypatch):
+    async def run():
+        screenshot_calls = 0
+
+        async def screenshot():
+            nonlocal screenshot_calls
+            screenshot_calls += 1
+            if screenshot_calls == 1:
+                await asyncio.Future()
+
+        agent = _agent(
+            monkeypatch,
+            timeout=0.5,
+            screenshot=screenshot,
+            num_concurrent_runs=1,
+        )
+        first_started = asyncio.Event()
+        first = agent.run(delay=0.2, success=True, started=first_started)
+        await asyncio.wait_for(first_started.wait(), timeout=1)
+        await asyncio.sleep(0.15)
+        second = agent.run(delay=0, success=True)
+
+        first_result = await first
+        second_result = await second
+
+        assert first_result.success is True
+        assert second_result.success is True
+        assert screenshot_calls == 2
 
     asyncio.run(run())

--- a/tests/test_finalization_workflow.py
+++ b/tests/test_finalization_workflow.py
@@ -1,0 +1,160 @@
+"""Exercise finalization through the real workflow timer and event stream."""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from llama_index.core.workflow import Context, StartEvent, Workflow, step
+from workflows.errors import WorkflowCancelledByUser, WorkflowTimeoutError
+
+import mobilerun.agent.droid.droid_agent as module
+from mobilerun.agent.droid.droid_agent import MobileAgent
+from mobilerun.agent.droid.events import (
+    FastAgentExecuteEvent,
+    FinalizeEvent,
+    ManagerInputEvent,
+    ResultEvent,
+)
+
+
+class FinishingAgent(MobileAgent):
+    """Replace device/LLM setup, retaining MobileAgent.run and finalize."""
+
+    def __init__(self, timeout):
+        Workflow.__init__(self, timeout=timeout)
+        self.timeout = timeout
+
+    @step
+    async def start_handler(
+        self, ctx: Context, ev: StartEvent
+    ) -> FastAgentExecuteEvent | ManagerInputEvent | FinalizeEvent:
+        await asyncio.sleep(ev.delay)
+        return FinalizeEvent(success=ev.success, reason="decided")
+
+
+def _agent(monkeypatch, timeout, screenshot):
+    async def flush(**kwargs):
+        pass
+
+    async def state():
+        return SimpleNamespace(elements=[])
+
+    monkeypatch.setattr(module, "capture", lambda *a, **kw: None)
+    monkeypatch.setattr(module, "flush", flush)
+    monkeypatch.setattr(module, "_FINALIZE_SCHEDULING_RESERVE_SECONDS", 0.05)
+    agent = FinishingAgent(timeout)
+    agent.shared_state = SimpleNamespace(
+        workflow_completed=False,
+        step_number=1,
+        visited_packages=set(),
+        visited_activities=set(),
+        telemetry_config_enabled=False,
+    )
+    agent.user_id = None
+    agent.output_model = None
+    agent.config = SimpleNamespace(
+        agent=SimpleNamespace(
+            manager=SimpleNamespace(vision=True),
+            executor=SimpleNamespace(vision=False),
+            fast_agent=SimpleNamespace(vision=False),
+        ),
+        logging=SimpleNamespace(save_trajectory="none", debug=False),
+        tracing=SimpleNamespace(langfuse_screenshots=False),
+    )
+    agent._stream_screenshots = False
+    agent.action_ctx = SimpleNamespace(driver=SimpleNamespace(screenshot=screenshot))
+    agent.state_provider = SimpleNamespace(get_state=state)
+    agent.mcp_manager = None
+    return agent
+
+
+@pytest.mark.parametrize("success", [True, False])
+def test_near_deadline_preserves_decision_and_terminates_stream(monkeypatch, success):
+    async def run():
+        entered = asyncio.Event()
+        cancelled = asyncio.Event()
+
+        async def screenshot():
+            entered.set()
+            try:
+                await asyncio.Future()
+            finally:
+                cancelled.set()
+
+        agent = _agent(monkeypatch, 0.6, screenshot)
+        handler = agent.run(delay=0.3, success=success)
+        events = [event async for event in handler.stream_events()]
+        result = await handler
+        assert entered.is_set(), "the hung epilog must actually run"
+        await asyncio.wait_for(cancelled.wait(), 0.5)
+        assert isinstance(result, ResultEvent)
+        assert (result.success, result.reason) == (success, "decided")
+        assert isinstance(events[-1], ResultEvent)
+        assert sum(isinstance(e, FinalizeEvent) for e in events) == 1
+        assert sum(isinstance(e, ResultEvent) for e in events) == 1
+
+    asyncio.run(run())
+
+
+def test_timeout_before_decision_still_fails(monkeypatch):
+    async def run():
+        async def screenshot():
+            raise AssertionError("finalization must not start")
+
+        agent = _agent(monkeypatch, 0.05, screenshot)
+        with pytest.raises(WorkflowTimeoutError):
+            await agent.run(delay=1, success=True)
+        assert agent.shared_state.workflow_completed is False
+
+    asyncio.run(run())
+
+
+def test_epilog_ceiling_applies_with_plenty_of_workflow_time(monkeypatch):
+    async def run():
+        entered = asyncio.Event()
+        cancelled = asyncio.Event()
+
+        async def screenshot():
+            entered.set()
+            try:
+                await asyncio.Future()
+            finally:
+                cancelled.set()
+
+        monkeypatch.setattr(module, "_FINALIZE_BUDGET_SECONDS", 0.15)
+        agent = _agent(monkeypatch, 60, screenshot)
+        handler = agent.run(delay=0, success=True)
+
+        async def collect():
+            return [event async for event in handler.stream_events()], await handler
+
+        events, result = await asyncio.wait_for(collect(), 1)
+        assert entered.is_set()
+        await asyncio.wait_for(cancelled.wait(), 0.5)
+        assert result.success is True
+        assert isinstance(events[-1], ResultEvent)
+
+    asyncio.run(run())
+
+
+def test_user_cancellation_during_epilog_still_cancels_workflow(monkeypatch):
+    async def run():
+        entered = asyncio.Event()
+        cancelled = asyncio.Event()
+
+        async def screenshot():
+            entered.set()
+            try:
+                await asyncio.Future()
+            finally:
+                cancelled.set()
+
+        agent = _agent(monkeypatch, 5, screenshot)
+        handler = agent.run(delay=0, success=True)
+        await asyncio.wait_for(entered.wait(), 1)
+        await handler.cancel_run()
+        with pytest.raises(WorkflowCancelledByUser):
+            await handler
+        await asyncio.wait_for(cancelled.wait(), 1)
+
+    asyncio.run(run())

--- a/tests/test_finalization_workflow.py
+++ b/tests/test_finalization_workflow.py
@@ -15,6 +15,7 @@ from mobilerun.agent.droid.events import (
     ManagerInputEvent,
     ResultEvent,
 )
+from mobilerun.agent.trajectory import TrajectoryWriter
 
 
 class FinishingAgent(MobileAgent):
@@ -31,6 +32,7 @@ class FinishingAgent(MobileAgent):
         self, ctx: Context, ev: StartEvent
     ) -> FastAgentExecuteEvent | ManagerInputEvent | FinalizeEvent:
         await self._initialize_workflow_deadline(ctx)
+        await self._initialize_run_trajectory()
         started = ev.get("started", default=None)
         if started is not None:
             started.set()
@@ -53,6 +55,7 @@ def _agent(monkeypatch, timeout, screenshot, *, num_concurrent_runs=None):
     monkeypatch.setattr(module, "_FINALIZE_SCHEDULING_RESERVE_SECONDS", 0.05)
     agent = FinishingAgent(timeout, num_concurrent_runs=num_concurrent_runs)
     agent.shared_state = SimpleNamespace(
+        instruction="test task",
         workflow_completed=False,
         step_number=1,
         visited_packages=set(),
@@ -61,17 +64,24 @@ def _agent(monkeypatch, timeout, screenshot, *, num_concurrent_runs=None):
     )
     agent.user_id = None
     agent.output_model = None
+    agent._using_external_agent = False
     agent.config = SimpleNamespace(
         agent=SimpleNamespace(
             manager=SimpleNamespace(vision=True),
             executor=SimpleNamespace(vision=False),
             fast_agent=SimpleNamespace(vision=False),
         ),
-        logging=SimpleNamespace(save_trajectory="none", debug=False),
+        logging=SimpleNamespace(
+            save_trajectory="none",
+            debug=False,
+            trajectory_path="trajectories",
+            trajectory_gifs=False,
+        ),
         tracing=SimpleNamespace(langfuse_screenshots=False),
     )
     agent._stream_screenshots = False
     agent.structured_output_llm = object()
+    agent.driver = None
     agent.action_ctx = SimpleNamespace(driver=SimpleNamespace(screenshot=screenshot))
     agent.state_provider = SimpleNamespace(get_state=state)
     agent.mcp_manager = None
@@ -246,5 +256,75 @@ def test_second_run_cannot_extend_active_run_deadline(monkeypatch):
         assert first_result.success is True
         assert second_result.success is True
         assert screenshot_calls == 2
+
+    asyncio.run(run())
+
+
+def test_serialized_runs_use_distinct_trajectory_writers(monkeypatch, tmp_path):
+    async def run():
+        first_draining = asyncio.Event()
+        release_first = asyncio.Event()
+        second_written = asyncio.Event()
+        writers = []
+
+        class RecordingWriter(TrajectoryWriter):
+            def __init__(self, queue_size=300):
+                super().__init__(queue_size=queue_size)
+                self.run_index = len(writers)
+                writers.append(self)
+
+            def write(self, trajectory, stage):
+                if stage != "final":
+                    return
+
+                run_index = self.run_index
+
+                class Job:
+                    async def execute(self):
+                        if run_index == 0:
+                            first_draining.set()
+                            await release_first.wait()
+                        else:
+                            second_written.set()
+
+                self.worker.submit(Job())
+
+        monkeypatch.setattr(module, "TrajectoryWriter", RecordingWriter)
+        monkeypatch.setattr(module, "_FINALIZE_BUDGET_SECONDS", 0.05)
+        monkeypatch.setattr(module, "_FINALIZE_TRAJECTORY_SECONDS", 0.5)
+        agent = _agent(
+            monkeypatch,
+            timeout=2,
+            screenshot=_no_screenshot,
+            num_concurrent_runs=1,
+        )
+        agent.config.agent.manager.vision = False
+        agent.config.logging.save_trajectory = "all"
+        agent.config.logging.trajectory_path = str(tmp_path)
+
+        first_result = await agent.run(delay=0, success=True, reason="first")
+        await asyncio.wait_for(first_draining.wait(), timeout=1)
+        second_result = await agent.run(delay=0, success=True, reason="second")
+
+        assert first_result.success is True
+        assert second_result.success is True
+        assert len(writers) == 2
+        assert writers[0] is not writers[1]
+        assert second_written.is_set()
+        assert writers[1].worker.queue.empty()
+
+        release_first.set()
+        background_cleanup = list(module._ABANDONED_FINALIZE_TASKS)
+        if background_cleanup:
+            await asyncio.wait_for(
+                asyncio.gather(*background_cleanup, return_exceptions=True),
+                timeout=1,
+            )
+        await asyncio.sleep(0)
+        assert not writers[0].worker.running
+        assert not writers[1].worker.running
+
+    async def _no_screenshot():
+        return None
 
     asyncio.run(run())

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -261,9 +261,16 @@ def test_mobile_agent_lifecycle_forwards_disabled_telemetry_config(
     class FakeContext:
         def __init__(self):
             self.events = []
+            self.store = self
 
         def write_event_to_stream(self, event) -> None:
             self.events.append(event)
+
+        async def set(self, key, value) -> None:
+            setattr(self, key, value)
+
+        async def get(self, key, default=None):
+            return getattr(self, key, default)
 
     captures = []
     flushes = []


### PR DESCRIPTION
An agent can finish its task but still raise `WorkflowTimeoutError` while finalization waits for structured output, telemetry, device observations, or cleanup. This preserves the decided success/reason by bounding asynchronous finalization against both the remaining workflow time and a shared 60-second ceiling.

- Structured extraction uses the available pre-cleanup time. Telemetry retains its 10-second limit; trajectory drain allows up to 30 seconds and MCP cleanup up to 3 seconds, within the shared deadline.
- Final screenshot and UI-state capture share a 15-second window. Android final state reads do not invoke recovery; normal agent reads retain retries and recovery.
- Overdue tasks are cancelled and reaped without waiting indefinitely for cancellation. Only completed observations are published. Caller cancellation still propagates, and trajectory shutdown is attempted even when final writes fail.

Validation: 760 tests and 3 subtests passed; Black 26.5.1 and scoped Ruff passed. Regression coverage includes real workflow deadlines and stream termination, structured-output result/event/error parity, late-task publication, and cleanup failure paths.

Real-device integration remains unverified. Async deadlines cannot preempt synchronous event-loop blocking or stop already-running worker threads. Direct structured extraction omits the nested workflow's tracing structure; MCP connection ownership is unchanged.

Supersedes #441.
