### PR TITLE
fix: refresh OAuth defaults and repair provider request compatibility

### DIFF
--- a/mobilerun/agent/providers/anthropic.py
+++ b/mobilerun/agent/providers/anthropic.py
@@ -5,15 +5,15 @@ from __future__ import annotations
 from collections.abc import MutableMapping
 from typing import Any
 
-ANTHROPIC_API_DEFAULT_MODEL = "claude-sonnet-4-6"
-ANTHROPIC_OAUTH_DEFAULT_MODEL = "claude-opus-4-7"
+ANTHROPIC_API_DEFAULT_MODEL = "claude-sonnet-5"
+ANTHROPIC_OAUTH_DEFAULT_MODEL = ANTHROPIC_API_DEFAULT_MODEL
 ANTHROPIC_FABLE_5_1_MODEL = "claude-fable-5-1"
 
 ANTHROPIC_API_MODELS = (
     ANTHROPIC_API_DEFAULT_MODEL,
     ANTHROPIC_FABLE_5_1_MODEL,
     "claude-opus-5",
-    "claude-sonnet-5",
+    "claude-sonnet-4-6",
     "claude-fable-5",
     "claude-opus-4-8",
     "claude-opus-4-6",
@@ -24,7 +24,7 @@ ANTHROPIC_OAUTH_MODELS = (
     ANTHROPIC_OAUTH_DEFAULT_MODEL,
     ANTHROPIC_FABLE_5_1_MODEL,
     "claude-opus-5",
-    "claude-sonnet-5",
+    "claude-opus-4-7",
     "claude-fable-5",
     "claude-opus-4-8",
     "claude-sonnet-4-6",

--- a/mobilerun/agent/providers/registry.py
+++ b/mobilerun/agent/providers/registry.py
@@ -39,8 +39,18 @@ VARIANT_ENV_KEY_SLOT: dict[str, str] = {
 OPENAI_MODEL_ALIASES: dict[str, str] = {
     "gpt-5.6": "gpt-5.6-sol",
 }
+OPENAI_OAUTH_DEFAULT_MODEL = "gpt-5.5"
+OPENAI_OAUTH_UNSUPPORTED_MODELS = frozenset(
+    {"gpt-5.3-codex", "gpt-5.4", "gpt-5.4-mini"}
+)
 
 GEMINI_API_DEFAULT_MODEL = "gemini-3.7-flash"
+GEMINI_OAUTH_DEFAULT_MODEL = "gemini-3.7-flash-tiered"
+# Antigravity still advertises these ids, but generation returns a retirement
+# notice instead of a model response. This does not apply to Developer API ids.
+GEMINI_OAUTH_RETIRED_MODELS = frozenset(
+    {"gemini-3.5-flash-low", "gemini-3.5-flash-extra-low", "gemini-3-flash-agent"}
+)
 GEMINI_API_MODELS: tuple[str, ...] = (
     GEMINI_API_DEFAULT_MODEL,
     "gemini-3.8-flash",
@@ -74,13 +84,11 @@ PROVIDER_FAMILIES: tuple[ProviderFamilySpec, ...] = (
                 runtime_provider_name="gemini_oauth_code_assist",
                 auth_mode="oauth",
                 # Antigravity consumer entitlement; ids from fetchAvailableModels.
-                default_model="gemini-3.5-flash-low",
+                default_model=GEMINI_OAUTH_DEFAULT_MODEL,
                 models=(
-                    "gemini-3.5-flash-low",
+                    GEMINI_OAUTH_DEFAULT_MODEL,
                     "gemini-3.8-flash-tiered",
-                    "gemini-3.7-flash-tiered",
-                    "gemini-3.5-flash-extra-low",
-                    "gemini-3-flash-agent",
+                    "gemini-3.5-flash-lite",
                     "gemini-3-flash",
                     "gemini-pro-agent",
                     "gemini-3.1-pro-low",
@@ -117,15 +125,13 @@ PROVIDER_FAMILIES: tuple[ProviderFamilySpec, ...] = (
                 id="openai_oauth",
                 runtime_provider_name="openai_oauth",
                 auth_mode="oauth",
-                default_model="gpt-5.5",
+                default_model=OPENAI_OAUTH_DEFAULT_MODEL,
                 models=(
-                    "gpt-5.5",
+                    OPENAI_OAUTH_DEFAULT_MODEL,
                     "gpt-6-astra",
                     "gpt-5.6-sol",
                     "gpt-5.6-terra",
                     "gpt-5.6-luna",
-                    "gpt-5.4",
-                    "gpt-5.4-mini",
                 ),
                 credential_path=str(OPENAI_OAUTH_CREDENTIAL_PATH),
             ),
@@ -323,7 +329,11 @@ def normalize_model_id_for_variant(
 ) -> str:
     """Normalize accepted model aliases to the canonical model id for a variant."""
     variant = resolve_provider_variant(family_id, auth_mode)
-    allowed_model_ids = set(variant.models)
+    known_model_ids = set(variant.models)
+    if family_id == "openai" and auth_mode == "oauth":
+        # Normalize unsupported OAuth ids with prefixes, so they reach the local
+        # unsupported-model error instead of bypassing validation.
+        known_model_ids.update(OPENAI_OAUTH_UNSUPPORTED_MODELS)
 
     alias_prefixes: tuple[str, ...] = ()
     if family_id == "openai" and auth_mode == "api_key":
@@ -342,7 +352,7 @@ def normalize_model_id_for_variant(
     elif family_id == "xai":
         candidate = normalize_grok_model_id(candidate)
 
-    if candidate in allowed_model_ids:
+    if candidate in known_model_ids:
         return candidate
 
     return model_id

--- a/mobilerun/agent/providers/registry.py
+++ b/mobilerun/agent/providers/registry.py
@@ -39,13 +39,15 @@ VARIANT_ENV_KEY_SLOT: dict[str, str] = {
 OPENAI_MODEL_ALIASES: dict[str, str] = {
     "gpt-5.6": "gpt-5.6-sol",
 }
-OPENAI_OAUTH_DEFAULT_MODEL = "gpt-5.5"
+OPENAI_API_DEFAULT_MODEL = "gpt-6-astra"
+OPENAI_OAUTH_DEFAULT_MODEL = OPENAI_API_DEFAULT_MODEL
+OPENAI_ASTRA_DEFAULT_REASONING_EFFORT = "low"
 OPENAI_OAUTH_UNSUPPORTED_MODELS = frozenset(
     {"gpt-5.3-codex", "gpt-5.4", "gpt-5.4-mini"}
 )
 
-GEMINI_API_DEFAULT_MODEL = "gemini-3.7-flash"
-GEMINI_OAUTH_DEFAULT_MODEL = "gemini-3.7-flash-tiered"
+GEMINI_API_DEFAULT_MODEL = "gemini-3.8-flash"
+GEMINI_OAUTH_DEFAULT_MODEL = "gemini-3.8-flash-tiered"
 # Antigravity still advertises these ids, but generation returns a retirement
 # notice instead of a model response. This does not apply to Developer API ids.
 GEMINI_OAUTH_RETIRED_MODELS = frozenset(
@@ -53,7 +55,7 @@ GEMINI_OAUTH_RETIRED_MODELS = frozenset(
 )
 GEMINI_API_MODELS: tuple[str, ...] = (
     GEMINI_API_DEFAULT_MODEL,
-    "gemini-3.8-flash",
+    "gemini-3.7-flash",
     "gemini-3.5-flash",
     "gemini-3.6-flash",
     "gemini-3.5-flash-lite",
@@ -87,7 +89,7 @@ PROVIDER_FAMILIES: tuple[ProviderFamilySpec, ...] = (
                 default_model=GEMINI_OAUTH_DEFAULT_MODEL,
                 models=(
                     GEMINI_OAUTH_DEFAULT_MODEL,
-                    "gemini-3.8-flash-tiered",
+                    "gemini-3.7-flash-tiered",
                     "gemini-3.5-flash-lite",
                     "gemini-3-flash",
                     "gemini-pro-agent",
@@ -108,10 +110,10 @@ PROVIDER_FAMILIES: tuple[ProviderFamilySpec, ...] = (
                 id="OpenAIResponses",
                 runtime_provider_name="OpenAIResponses",
                 auth_mode="api_key",
-                default_model="gpt-5.5",
+                default_model=OPENAI_API_DEFAULT_MODEL,
                 models=(
+                    OPENAI_API_DEFAULT_MODEL,
                     "gpt-5.5",
-                    "gpt-6-astra",
                     "gpt-5.6-sol",
                     "gpt-5.6-terra",
                     "gpt-5.6-luna",
@@ -128,7 +130,7 @@ PROVIDER_FAMILIES: tuple[ProviderFamilySpec, ...] = (
                 default_model=OPENAI_OAUTH_DEFAULT_MODEL,
                 models=(
                     OPENAI_OAUTH_DEFAULT_MODEL,
-                    "gpt-6-astra",
+                    "gpt-5.5",
                     "gpt-5.6-sol",
                     "gpt-5.6-terra",
                     "gpt-5.6-luna",

--- a/mobilerun/agent/utils/llm_picker.py
+++ b/mobilerun/agent/utils/llm_picker.py
@@ -7,6 +7,7 @@ from llama_index.core.base.llms.types import LLMMetadata
 from llama_index.core.llms.llm import LLM
 
 from mobilerun.agent.providers.anthropic import (
+    ANTHROPIC_API_DEFAULT_MODEL,
     ANTHROPIC_FABLE_5_1_MODEL,
     ANTHROPIC_UNSUPPORTED_SAMPLING_PARAMS,
     anthropic_model_context_window,
@@ -24,6 +25,9 @@ from mobilerun.agent.providers.minimax import (
     warn_if_legacy_minimax_endpoint,
 )
 from mobilerun.agent.providers.registry import (
+    GEMINI_API_DEFAULT_MODEL,
+    OPENAI_API_DEFAULT_MODEL,
+    OPENAI_ASTRA_DEFAULT_REASONING_EFFORT,
     OPENAI_OAUTH_UNSUPPORTED_MODELS,
     list_models_for_variant,
     normalize_model_id_for_variant,
@@ -286,6 +290,10 @@ def _load_openai_responses(*, grok: bool = False, **kwargs: Any) -> LLM:
                 or effective_model == OPENAI_ASTRA_MODEL
             ):
                 sanitized = self._sanitize_astra_payload_fields(sanitized)
+                # Apply the default after configured and per-call overrides.
+                sanitized.setdefault(
+                    "reasoning", {"effort": OPENAI_ASTRA_DEFAULT_REASONING_EFFORT}
+                )
                 extra_body = sanitized.get("extra_body")
                 if isinstance(extra_body, dict):
                     sanitized["extra_body"] = self._sanitize_astra_payload_fields(
@@ -790,6 +798,7 @@ def load_llm(provider_name: str, model: str | None = None, **kwargs: Any) -> LLM
 
     # --- Standard providers (inline dispatch) ---
     if provider_name == "OpenAIResponses":
+        kwargs.setdefault("model", OPENAI_API_DEFAULT_MODEL)
         return _load_openai_responses(**kwargs)
     elif provider_name == "OpenAILike":
         from llama_index.llms.openai_like import OpenAILike
@@ -799,6 +808,7 @@ def load_llm(provider_name: str, model: str | None = None, **kwargs: Any) -> LLM
         if "base_url" in kwargs and "api_base" not in kwargs:
             kwargs["api_base"] = kwargs.pop("base_url")
     elif provider_name == "GoogleGenAI":
+        kwargs.setdefault("model", GEMINI_API_DEFAULT_MODEL)
         return _load_google_genai(**kwargs)
     elif provider_name == "Ollama":
         from llama_index.llms.ollama import Ollama
@@ -806,6 +816,7 @@ def load_llm(provider_name: str, model: str | None = None, **kwargs: Any) -> LLM
         llm_class = Ollama
         kwargs = _prepare_ollama_kwargs(kwargs, Ollama)
     elif provider_name == "Anthropic":
+        kwargs.setdefault("model", ANTHROPIC_API_DEFAULT_MODEL)
         return _load_anthropic(**kwargs)
     elif provider_name == "OpenRouter":
         from llama_index.llms.openrouter import OpenRouter

--- a/mobilerun/agent/utils/llm_picker.py
+++ b/mobilerun/agent/utils/llm_picker.py
@@ -1,4 +1,6 @@
+import inspect
 import logging
+from functools import wraps
 from typing import TYPE_CHECKING, Any
 
 from llama_index.core.base.llms.types import LLMMetadata
@@ -22,6 +24,7 @@ from mobilerun.agent.providers.minimax import (
     warn_if_legacy_minimax_endpoint,
 )
 from mobilerun.agent.providers.registry import (
+    OPENAI_OAUTH_UNSUPPORTED_MODELS,
     list_models_for_variant,
     normalize_model_id_for_variant,
 )
@@ -70,12 +73,10 @@ GEMINI_OAUTH_UNSUPPORTED_MODELS = {
     "gemini-3.8-flash",
     "gemini-3.7-flash",
     "gemini-3.6-flash",
-    "gemini-3.5-flash-lite",
     "gemini-3.5-flash",
     "gemini-3-flash-preview",
     "gemini-3.1-pro-preview",
 }
-OPENAI_OAUTH_UNSUPPORTED_MODELS = {"gpt-5.3-codex"}
 OPENAI_RESPONSES_MODELS_WITHOUT_SAMPLING_PARAMS = {
     "gpt-6-astra",
     "gpt-5.5",
@@ -567,6 +568,14 @@ def _load_anthropic(**kwargs: Any) -> LLM:
     from llama_index.llms.anthropic import Anthropic
 
     class MobilerunAnthropic(Anthropic):
+        @wraps(Anthropic._prepare_chat_with_tools)
+        def _prepare_chat_with_tools(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+            # FunctionCallingProgram passes None by default, overwriting the
+            # valid tool-choice object built by the upstream adapter.
+            if kwargs.get("tool_choice") is None:
+                kwargs.pop("tool_choice", None)
+            return super()._prepare_chat_with_tools(*args, **kwargs)
+
         @property
         def _model_kwargs(self) -> dict[str, Any]:
             model_kwargs = super()._model_kwargs
@@ -578,10 +587,42 @@ def _load_anthropic(**kwargs: Any) -> LLM:
 
         def _get_all_kwargs(self, **kwargs: Any) -> dict[str, Any]:
             model_kwargs = super()._get_all_kwargs(**kwargs)
-            effective_model = model_kwargs.get("model", self.model)
+            # LlamaIndex's structured program supplies an OpenAI-style string
+            # after the Anthropic adapter has prepared its tool choice.
+            tool_choice = model_kwargs.get("tool_choice")
+            if isinstance(tool_choice, str) and tool_choice in {
+                "auto",
+                "required",
+                "none",
+            }:
+                model_kwargs["tool_choice"] = {
+                    "type": "any" if tool_choice == "required" else tool_choice
+                }
+            extra_body = dict(model_kwargs.get("extra_body") or {})
+            effective_model = extra_body.get(
+                "model", model_kwargs.get("model", self.model)
+            )
             if anthropic_model_omits_sampling_params(effective_model):
                 for param in ANTHROPIC_UNSUPPORTED_SAMPLING_PARAMS:
                     model_kwargs.pop(param, None)
+                    extra_body.pop(param, None)
+            else:
+                # Anthropic SDK 1.x removed named sampling arguments even for
+                # older models whose HTTP API still supports them. Preserve
+                # the SDK's extra_body precedence and older SDK signatures.
+                parameters = inspect.signature(self._client.messages.create).parameters
+                accepts_kwargs = any(
+                    p.kind == inspect.Parameter.VAR_KEYWORD for p in parameters.values()
+                )
+                for param in ANTHROPIC_UNSUPPORTED_SAMPLING_PARAMS:
+                    if (
+                        param in model_kwargs
+                        and param not in parameters
+                        and not accepts_kwargs
+                    ):
+                        extra_body.setdefault(param, model_kwargs.pop(param))
+            if extra_body or "extra_body" in model_kwargs:
+                model_kwargs["extra_body"] = extra_body
             return model_kwargs
 
         @property

--- a/mobilerun/agent/utils/oauth/anthropic_oauth_llm.py
+++ b/mobilerun/agent/utils/oauth/anthropic_oauth_llm.py
@@ -33,7 +33,6 @@ from llama_index.core.llms.callbacks import llm_chat_callback, llm_completion_ca
 from llama_index.core.llms.custom import CustomLLM
 
 from mobilerun.agent.providers.anthropic import (
-    ANTHROPIC_FABLE_5_1_MODEL,
     ANTHROPIC_OAUTH_DEFAULT_MODEL,
     anthropic_model_context_window,
     anthropic_model_omits_sampling_params,
@@ -244,7 +243,9 @@ class AnthropicOAuthLLM(CustomLLM):
             num_output=self.max_tokens or -1,
             model_name=self.model,
             is_chat_model=True,
-            is_function_calling_model=self.model != ANTHROPIC_FABLE_5_1_MODEL,
+            # This text/image adapter does not implement native function calls.
+            # Structured extraction must use the validated text program.
+            is_function_calling_model=False,
         )
 
     def _load_credentials_from_file(self, credential_path: str) -> None:

--- a/mobilerun/agent/utils/oauth/gemini_oauth_code_assist_llm.py
+++ b/mobilerun/agent/utils/oauth/gemini_oauth_code_assist_llm.py
@@ -32,7 +32,11 @@ from llama_index.core.constants import DEFAULT_TEMPERATURE
 from llama_index.core.llms.callbacks import llm_chat_callback, llm_completion_callback
 from llama_index.core.llms.custom import CustomLLM
 
-from mobilerun.agent.providers.registry import model_display_name_for_variant
+from mobilerun.agent.providers.registry import (
+    GEMINI_OAUTH_DEFAULT_MODEL,
+    GEMINI_OAUTH_RETIRED_MODELS,
+    model_display_name_for_variant,
+)
 from mobilerun.agent.utils.oauth.login_timeout import (
     OAuthLoginDeadline,
     open_browser_async,
@@ -40,7 +44,7 @@ from mobilerun.agent.utils.oauth.login_timeout import (
 from mobilerun.config_manager.auth_profile_store import AuthProfileStore
 from mobilerun.config_manager.credential_paths import GEMINI_OAUTH_CREDENTIAL_PATH
 
-DEFAULT_MODEL = "gemini-3.5-flash-low"
+DEFAULT_MODEL = GEMINI_OAUTH_DEFAULT_MODEL
 DEFAULT_CODE_ASSIST_ENDPOINT = "https://daily-cloudcode-pa.googleapis.com"
 DEFAULT_CODE_ASSIST_API_VERSION = "v1internal"
 DEFAULT_CODE_ASSIST_MODELS_METHOD = "fetchAvailableModels"
@@ -139,9 +143,9 @@ class GeminiOAuthCodeAssistLLM(CustomLLM):
     """
 
     MODEL_PRESETS: ClassVar[Dict[str, str]] = {
-        "flash": "gemini-3.5-flash-low",
+        "flash": GEMINI_OAUTH_DEFAULT_MODEL,
         "pro": "gemini-pro-agent",
-        "flash_lite": "gemini-3.5-flash-extra-low",
+        "flash_lite": "gemini-3.5-flash-lite",
     }
 
     model: str = Field(default=DEFAULT_MODEL, description="Gemini model id.")
@@ -222,6 +226,13 @@ class GeminiOAuthCodeAssistLLM(CustomLLM):
                 selected_model = self.MODEL_PRESETS[model_preset]
             else:
                 selected_model = DEFAULT_MODEL
+
+        if selected_model in GEMINI_OAUTH_RETIRED_MODELS:
+            raise ValueError(
+                f"Gemini OAuth model '{selected_model}' is retired. "
+                f"Use '{GEMINI_OAUTH_DEFAULT_MODEL}' or re-run "
+                "`mobilerun configure gemini` to choose an available model."
+            )
 
         super().__init__(
             model=selected_model,
@@ -373,6 +384,7 @@ class GeminiOAuthCodeAssistLLM(CustomLLM):
         if not isinstance(models, dict):
             return []
         deprecated = set((data.get("deprecatedModelIds") or {}).keys())
+        deprecated.update(GEMINI_OAUTH_RETIRED_MODELS)
         out: list[Dict[str, Any]] = []
         for model_id, meta in models.items():
             if not isinstance(meta, dict) or model_id in deprecated:

--- a/mobilerun/agent/utils/oauth/openai_oauth_llm.py
+++ b/mobilerun/agent/utils/oauth/openai_oauth_llm.py
@@ -43,6 +43,7 @@ from llama_index.llms.openai.base import llm_retry_decorator
 from llama_index.llms.openai.utils import to_openai_message_dicts
 
 from mobilerun.agent.providers.registry import (
+    OPENAI_ASTRA_DEFAULT_REASONING_EFFORT,
     OPENAI_OAUTH_DEFAULT_MODEL,
     OPENAI_OAUTH_UNSUPPORTED_MODELS,
     normalize_model_id_for_variant,
@@ -1091,6 +1092,9 @@ class OpenAIOAuth(OpenAI):
             merged["reasoning"] = {"effort": self.reasoning_effort}
         merged.update(self.additional_kwargs or {})
         merged.update(runtime_kwargs)
+        merged.setdefault(
+            "reasoning", {"effort": OPENAI_ASTRA_DEFAULT_REASONING_EFFORT}
+        )
 
         for key in _GPT_6_ASTRA_UNSUPPORTED_PARAMS:
             merged.pop(key, None)

--- a/mobilerun/agent/utils/oauth/openai_oauth_llm.py
+++ b/mobilerun/agent/utils/oauth/openai_oauth_llm.py
@@ -4,8 +4,8 @@ Usage:
     from openai_oauth_llm import OpenAIOAuth
 
     llm = OpenAIOAuth(
-        auth_model="openai-codex/gpt-5.4",
-        custom_model="gpt-5.4",  # optional override
+        auth_model="openai-codex/gpt-5.5",
+        custom_model="gpt-5.5",  # optional override
         oauth_refresh_token="rt_...",
         oauth_access_token="eyJ...",  # optional if cached file already exists
         oauth_credential_path=str(OPENAI_OAUTH_CREDENTIAL_PATH),
@@ -37,11 +37,16 @@ from llama_index.core.base.llms.types import (
     LLMMetadata,
     MessageRole,
 )
+from llama_index.core.types import PydanticProgramMode
 from llama_index.llms.openai import OpenAI
 from llama_index.llms.openai.base import llm_retry_decorator
 from llama_index.llms.openai.utils import to_openai_message_dicts
 
-from mobilerun.agent.providers.registry import normalize_model_id_for_variant
+from mobilerun.agent.providers.registry import (
+    OPENAI_OAUTH_DEFAULT_MODEL,
+    OPENAI_OAUTH_UNSUPPORTED_MODELS,
+    normalize_model_id_for_variant,
+)
 from mobilerun.agent.utils.oauth.login_timeout import (
     OAuthLoginDeadline,
     open_browser_async,
@@ -52,7 +57,7 @@ from mobilerun.config_manager.credential_paths import OPENAI_OAUTH_CREDENTIAL_PA
 DEFAULT_OPENAI_OAUTH_ISSUER = "https://auth.openai.com"
 DEFAULT_OPENAI_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 DEFAULT_OPENAI_OAUTH_CREDENTIAL_PATH = OPENAI_OAUTH_CREDENTIAL_PATH
-DEFAULT_AUTH_MODEL = "openai-codex/gpt-5.4"
+DEFAULT_AUTH_MODEL = f"openai-codex/{OPENAI_OAUTH_DEFAULT_MODEL}"
 DEFAULT_OPENAI_API_BASE = "https://api.openai.com/v1"
 DEFAULT_CODEX_API_BASE = "https://chatgpt.com/backend-api/codex"
 DEFAULT_BACKEND_API_BASE = "https://chatgpt.com/backend-api"
@@ -617,7 +622,7 @@ class OpenAIOAuth(OpenAI):
         elif model and model.strip():
             selected_model = model.strip()
         else:
-            selected_model = auth_model.strip() or "gpt-5.4"
+            selected_model = auth_model.strip() or OPENAI_OAUTH_DEFAULT_MODEL
 
         normalized_model = normalize_model_id_for_variant(
             "openai",
@@ -683,9 +688,19 @@ class OpenAIOAuth(OpenAI):
             custom_model=custom_model,
             model=model,
         )
+        if resolved_model in OPENAI_OAUTH_UNSUPPORTED_MODELS:
+            raise ValueError(
+                f"Model '{resolved_model}' is not supported with OpenAI OAuth "
+                f"ChatGPT-account credentials. Use '{OPENAI_OAUTH_DEFAULT_MODEL}' "
+                "or re-run `mobilerun configure openai`."
+            )
 
         seed_api_key = oauth_access_token or kwargs.pop("api_key", None) or "oauth"
         kwargs.setdefault("api_base", DEFAULT_OPENAI_API_BASE)
+        # This adapter collects Responses text, without forwarding Chat
+        # Completions response_format or function tools. Include the schema
+        # in the prompt and validate the returned JSON through LlamaIndex.
+        kwargs.setdefault("pydantic_program_mode", PydanticProgramMode.LLM)
         super().__init__(model=resolved_model, api_key=seed_api_key, **kwargs)
         object.__setattr__(
             self,

--- a/tests/test_anthropic_oauth_llm.py
+++ b/tests/test_anthropic_oauth_llm.py
@@ -56,10 +56,10 @@ def test_default_max_tokens_is_8192():
     assert AnthropicOAuthLLM(credential_path=None).metadata.num_output == 8192
 
 
-def test_default_opus_payload_sends_max_tokens_without_temperature():
+def test_default_sonnet_payload_sends_max_tokens_without_temperature():
     payload = _payload_for()
 
-    assert payload["model"] == "claude-opus-4-7"
+    assert payload["model"] == "claude-sonnet-5"
     assert payload["max_tokens"] == 8192
     assert "temperature" not in payload
 

--- a/tests/test_anthropic_oauth_llm.py
+++ b/tests/test_anthropic_oauth_llm.py
@@ -140,7 +140,10 @@ def test_fable_5_1_uses_current_claude_code_identity_defaults():
     assert f"cc_version={DEFAULT_CC_VERSION};" in session.payload["system"][0]["text"]
 
 
-def test_fable_5_1_structured_predict_uses_text_pydantic_extraction(monkeypatch):
+@pytest.mark.parametrize(
+    "model", ["claude-fable-5-1", "claude-opus-4-7", "claude-haiku-4-5"]
+)
+def test_oauth_structured_predict_uses_text_pydantic_extraction(monkeypatch, model):
     from llama_index.core.base.llms.types import ChatResponse
     from llama_index.core.prompts import PromptTemplate
     from pydantic import BaseModel
@@ -149,7 +152,7 @@ def test_fable_5_1_structured_predict_uses_text_pydantic_extraction(monkeypatch)
         value: str
 
     llm = AnthropicOAuthLLM(
-        model="claude-fable-5-1",
+        model=model,
         access_token="test-token",
         credential_path=None,
     )
@@ -174,7 +177,7 @@ def test_fable_5_1_structured_predict_uses_text_pydantic_extraction(monkeypatch)
     assert result == StructuredResult(value="OK")
     assert (
         AnthropicOAuthLLM(credential_path=None).metadata.is_function_calling_model
-        is True
+        is False
     )
 
 

--- a/tests/test_anthropic_sdk_sampling.py
+++ b/tests/test_anthropic_sdk_sampling.py
@@ -1,0 +1,196 @@
+"""Exercise sampling payloads at the actual Anthropic SDK HTTP boundary."""
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+import anthropic
+import pytest
+
+try:
+    from anthropic._base_client import httpx2 as httpx
+except ImportError:
+    import httpx
+from llama_index.core.llms import ChatMessage
+
+from mobilerun.agent.utils.llm_picker import load_llm
+
+
+@pytest.mark.parametrize("async_call", [False, True])
+@pytest.mark.parametrize(
+    "model,extra_body,expected",
+    [
+        (
+            "claude-haiku-4-5",
+            {"temperature": 0.7, "metadata": {"user_id": "test"}},
+            {"temperature": 0.7, "top_p": 0.6, "top_k": 10},
+        ),
+        ("claude-sonnet-4-6", {}, {"temperature": 0.2, "top_p": 0.6, "top_k": 10}),
+        ("claude-opus-4-8", {"temperature": 0.7, "top_p": 0.3, "top_k": 1}, {}),
+        ("claude-sonnet-4-6", {"model": "claude-opus-4-8", "temperature": 0.7}, {}),
+    ],
+)
+def test_sdk_request_preserves_supported_sampling_only(
+    async_call, model, extra_body, expected
+):
+    captured = []
+
+    def respond(request):
+        captured.append(json.loads(request.content))
+        return httpx.Response(
+            200,
+            json={
+                "id": "msg_test",
+                "type": "message",
+                "role": "assistant",
+                "model": model,
+                "content": [{"type": "text", "text": "READY"}],
+                "stop_reason": "end_turn",
+                "stop_sequence": None,
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            },
+        )
+
+    llm = load_llm(
+        "Anthropic",
+        model=model,
+        api_key="test-key",
+        temperature=0.2,
+        additional_kwargs={"top_p": 0.6},
+    )
+    body_before = dict(extra_body)
+    messages = [ChatMessage(role="user", content="Reply READY")]
+    if async_call:
+
+        async def run():
+            async with anthropic.AsyncAnthropic(
+                api_key="test-key",
+                http_client=httpx.AsyncClient(transport=httpx.MockTransport(respond)),
+            ) as client:
+                llm._aclient = client
+                return await llm.achat(messages, top_k=10, extra_body=extra_body)
+
+        result = asyncio.run(run())
+    else:
+        with anthropic.Anthropic(
+            api_key="test-key",
+            http_client=httpx.Client(transport=httpx.MockTransport(respond)),
+        ) as client:
+            llm._client = client
+            result = llm.chat(messages, top_k=10, extra_body=extra_body)
+
+    assert result.message.content == "READY"
+    payload = captured[0]
+    assert {
+        k: payload[k] for k in ("temperature", "top_p", "top_k") if k in payload
+    } == expected
+    assert payload["model"] == extra_body.get("model", model)
+    assert "extra_body" not in payload
+    if "metadata" in extra_body:
+        assert payload["metadata"] == extra_body["metadata"]
+    assert extra_body == body_before
+
+
+@pytest.mark.parametrize("named_sampling", [False, True])
+def test_sampling_adapts_to_installed_sdk_signature(named_sampling):
+    def old_create(*, temperature=None, top_p=None, top_k=None, extra_body=None):
+        pass
+
+    def new_create(*, extra_body=None):
+        pass
+
+    llm = load_llm(
+        "Anthropic", model="claude-haiku-4-5", api_key="test-key", temperature=0.2
+    )
+    llm._client = SimpleNamespace(
+        messages=SimpleNamespace(create=old_create if named_sampling else new_create)
+    )
+    kwargs = llm._get_all_kwargs(top_p=0.6, top_k=10, extra_body={"temperature": 0.7})
+    assert ("temperature" in kwargs) is named_sampling
+    assert {**kwargs, **kwargs["extra_body"]}["temperature"] == 0.7
+    assert {**kwargs, **kwargs["extra_body"]}["top_p"] == 0.6
+    assert {**kwargs, **kwargs["extra_body"]}["top_k"] == 10
+
+
+@pytest.mark.parametrize("async_call", [False, True])
+@pytest.mark.parametrize(
+    "tool_choice,expected",
+    [
+        (None, {"disable_parallel_tool_use": True, "type": "any"}),
+        ("required", {"type": "any"}),
+        ("auto", {"type": "auto"}),
+        ({"type": "tool", "name": "Result"}, {"type": "tool", "name": "Result"}),
+    ],
+)
+def test_structured_extraction_sends_anthropic_tool_choice(
+    async_call, tool_choice, expected
+):
+    from llama_index.core.program.function_program import FunctionCallingProgram
+    from llama_index.core.prompts import PromptTemplate
+    from pydantic import BaseModel
+
+    class Result(BaseModel):
+        value: int
+
+    captured = []
+
+    def respond(request):
+        captured.append(json.loads(request.content))
+        return httpx.Response(
+            200,
+            json={
+                "id": "msg_test",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-sonnet-4-6",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tool_test",
+                        "name": "Result",
+                        "input": {"value": 19},
+                    }
+                ],
+                "stop_reason": "tool_use",
+                "stop_sequence": None,
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            },
+        )
+
+    llm = load_llm("Anthropic", model="claude-sonnet-4-6", api_key="test-key")
+    prompt = PromptTemplate("Return 8 plus 11 as value.")
+    program = FunctionCallingProgram.from_defaults(
+        output_cls=Result, llm=llm, prompt=prompt, tool_choice=tool_choice
+    )
+    if async_call:
+
+        async def run():
+            async with anthropic.AsyncAnthropic(
+                api_key="test-key",
+                http_client=httpx.AsyncClient(transport=httpx.MockTransport(respond)),
+            ) as client:
+                llm._aclient = client
+                return (
+                    await llm.astructured_predict(Result, prompt)
+                    if tool_choice is None
+                    else await program.acall()
+                )
+
+        result = asyncio.run(run())
+    else:
+        with anthropic.Anthropic(
+            api_key="test-key",
+            http_client=httpx.Client(transport=httpx.MockTransport(respond)),
+        ) as client:
+            llm._client = client
+            result = (
+                llm.structured_predict(Result, prompt)
+                if tool_choice is None
+                else program()
+            )
+    assert result.value == 19
+    assert captured[0]["tool_choice"] == expected
+    assert (
+        captured[0]["tools"][0]["input_schema"]["properties"]["value"]["type"]
+        == "integer"
+    )

--- a/tests/test_gemini_oauth_llm.py
+++ b/tests/test_gemini_oauth_llm.py
@@ -394,10 +394,68 @@ def test_system_message_text_reaches_system_instruction():
 
 
 def test_oauth_default_model_resolves_to_antigravity_flash():
+    from mobilerun.agent.providers.registry import resolve_provider_variant
     from mobilerun.agent.utils.llm_picker import load_llm
+    from mobilerun.cli.oauth_actions import GEMINI_OAUTH_DEFAULT_MODEL
 
     # no model arg -> the Antigravity consumer default
-    assert load_llm("gemini_oauth_code_assist").model == "gemini-3.5-flash-low"
+    assert load_llm("gemini_oauth_code_assist").model == "gemini-3.7-flash-tiered"
+    variant = resolve_provider_variant("gemini", "oauth")
+    assert variant.models[0] == variant.default_model == GEMINI_OAUTH_DEFAULT_MODEL
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["gemini-3.5-flash-low", "gemini-3.5-flash-extra-low", "gemini-3-flash-agent"],
+)
+@pytest.mark.parametrize("argument", ["model", "custom_model"])
+def test_retired_oauth_models_fail_before_loading_credentials(
+    model, argument, monkeypatch
+):
+    from mobilerun.agent.utils.oauth.gemini_oauth_code_assist_llm import (
+        GeminiOAuthCodeAssistLLM,
+    )
+
+    def unexpected_load(*args):
+        pytest.fail("Retired selection must fail before credentials or network access")
+
+    monkeypatch.setattr(
+        GeminiOAuthCodeAssistLLM, "_load_credentials_from_file", unexpected_load
+    )
+    with pytest.raises(ValueError, match="retired.*gemini-3.7-flash-tiered.*configure"):
+        GeminiOAuthCodeAssistLLM(**{argument: model})
+
+
+def test_retired_oauth_models_are_hidden_even_when_provider_advertises_them():
+    from mobilerun.agent.providers.registry import GEMINI_OAUTH_RETIRED_MODELS
+
+    advertised = [
+        *GEMINI_OAUTH_RETIRED_MODELS,
+        "gemini-3.5-flash-lite",
+        "gemini-future-custom",
+    ]
+    models = _models_from_catalog(
+        {
+            "models": {
+                model: {
+                    "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
+                    "displayName": model,
+                }
+                for model in advertised
+            }
+        }
+    )
+    assert [model["id"] for model in models] == [
+        "gemini-3.5-flash-lite",
+        "gemini-future-custom",
+    ]
+
+
+def test_flash_lite_and_unknown_custom_oauth_models_load():
+    from mobilerun.agent.utils.llm_picker import load_llm
+
+    for model in ("gemini-3.5-flash-lite", "gemini-future-custom"):
+        assert load_llm("gemini_oauth_code_assist", model=model).model == model
 
 
 def test_oauth_explicit_default_model_is_honored_not_preset():
@@ -405,8 +463,8 @@ def test_oauth_explicit_default_model_is_honored_not_preset():
 
     # explicit model equal to DEFAULT_MODEL must NOT fall through to a preset
     assert (
-        load_llm("gemini_oauth_code_assist", model="gemini-3.5-flash-low").model
-        == "gemini-3.5-flash-low"
+        load_llm("gemini_oauth_code_assist", model="gemini-3.7-flash-tiered").model
+        == "gemini-3.7-flash-tiered"
     )
 
 
@@ -430,7 +488,8 @@ def test_oauth_preset_key_still_resolves():
     )
 
     assert (
-        GeminiOAuthCodeAssistLLM(model_preset="flash").model == "gemini-3.5-flash-low"
+        GeminiOAuthCodeAssistLLM(model_preset="flash").model
+        == "gemini-3.7-flash-tiered"
     )
 
 
@@ -494,7 +553,7 @@ def test_flash_lite_preset_resolves_to_picker_model():
 
     assert (
         GeminiOAuthCodeAssistLLM(model_preset="flash_lite").model
-        == "gemini-3.5-flash-extra-low"
+        == "gemini-3.5-flash-lite"
     )
 
 

--- a/tests/test_gemini_oauth_llm.py
+++ b/tests/test_gemini_oauth_llm.py
@@ -399,7 +399,7 @@ def test_oauth_default_model_resolves_to_antigravity_flash():
     from mobilerun.cli.oauth_actions import GEMINI_OAUTH_DEFAULT_MODEL
 
     # no model arg -> the Antigravity consumer default
-    assert load_llm("gemini_oauth_code_assist").model == "gemini-3.7-flash-tiered"
+    assert load_llm("gemini_oauth_code_assist").model == "gemini-3.8-flash-tiered"
     variant = resolve_provider_variant("gemini", "oauth")
     assert variant.models[0] == variant.default_model == GEMINI_OAUTH_DEFAULT_MODEL
 
@@ -422,7 +422,7 @@ def test_retired_oauth_models_fail_before_loading_credentials(
     monkeypatch.setattr(
         GeminiOAuthCodeAssistLLM, "_load_credentials_from_file", unexpected_load
     )
-    with pytest.raises(ValueError, match="retired.*gemini-3.7-flash-tiered.*configure"):
+    with pytest.raises(ValueError, match="retired.*gemini-3.8-flash-tiered.*configure"):
         GeminiOAuthCodeAssistLLM(**{argument: model})
 
 
@@ -489,7 +489,7 @@ def test_oauth_preset_key_still_resolves():
 
     assert (
         GeminiOAuthCodeAssistLLM(model_preset="flash").model
-        == "gemini-3.7-flash-tiered"
+        == "gemini-3.8-flash-tiered"
     )
 
 

--- a/tests/test_grok_cli.py
+++ b/tests/test_grok_cli.py
@@ -195,7 +195,7 @@ def test_gemini_empty_entitlement_is_not_persisted(monkeypatch, tmp_path) -> Non
     with pytest.raises(RuntimeError, match="no usable models"):
         oauth_actions.run_gemini_oauth_login(
             str(tmp_path / "auth.json"),
-            "gemini-3.5-flash-low",
+            "gemini-3.7-flash-tiered",
             open_browser=False,
         )
 

--- a/tests/test_llm_picker.py
+++ b/tests/test_llm_picker.py
@@ -416,7 +416,6 @@ def test_openai_oauth_rejects_unsupported_codex_model() -> None:
         "gemini-3.8-flash",
         "gemini-3.7-flash",
         "gemini-3.6-flash",
-        "gemini-3.5-flash-lite",
         "gemini-3.5-flash",
         "gemini-3-flash-preview",
         "gemini-3.1-pro-preview",
@@ -906,9 +905,10 @@ def test_anthropic_opus_4_6_keeps_supported_sampling() -> None:
 
     kwargs = llm._get_all_kwargs(top_k=10)
 
-    assert kwargs["temperature"] == 0.2
-    assert kwargs["top_p"] == 0.6
-    assert kwargs["top_k"] == 10
+    payload = {**kwargs, **kwargs.get("extra_body", {})}
+    assert payload["temperature"] == 0.2
+    assert payload["top_p"] == 0.6
+    assert payload["top_k"] == 10
 
 
 def test_anthropic_sonnet_keeps_temperature() -> None:
@@ -922,7 +922,7 @@ def test_anthropic_sonnet_keeps_temperature() -> None:
     kwargs = llm._get_all_kwargs()
 
     assert kwargs["model"] == "claude-sonnet-4-6"
-    assert kwargs["temperature"] == 0.2
+    assert {**kwargs, **kwargs.get("extra_body", {})}["temperature"] == 0.2
 
 
 def test_anthropic_uses_a_2048_token_default() -> None:

--- a/tests/test_llm_picker.py
+++ b/tests/test_llm_picker.py
@@ -130,6 +130,7 @@ def test_openai_structured_predict_omits_per_call_sampling_params(
         assert {"temperature", "top_p"}.isdisjoint(payload)
         if model == "gpt-6-astra":
             assert {"top_logprobs", "logprobs"}.isdisjoint(payload)
+            assert payload["reasoning"] == {"effort": "low"}
         assert payload["max_output_tokens"] == 32
 
 

--- a/tests/test_openai_oauth_llm.py
+++ b/tests/test_openai_oauth_llm.py
@@ -216,10 +216,7 @@ def test_gpt_6_astra_forwards_supported_reasoning_only(
     request = create_response.call_args.kwargs
     assert request["model"] == "gpt-6-astra"
     assert llm.metadata.context_window == 400_000
-    if effort is None:
-        assert "reasoning" not in request
-    else:
-        assert request["reasoning"] == {"effort": effort}
+    assert request["reasoning"] == {"effort": effort or "low"}
     assert request["include"] == ["reasoning.encrypted_content"]
     assert {"temperature", "top_p", "logprobs", "top_logprobs"}.isdisjoint(request)
 
@@ -365,7 +362,7 @@ def test_oauth_implicit_default_matches_catalog(tmp_path):
     assert (
         llm.model
         == resolve_provider_variant("openai", "oauth").default_model
-        == "gpt-5.5"
+        == "gpt-6-astra"
     )
 
 
@@ -373,7 +370,7 @@ def test_oauth_implicit_default_matches_catalog(tmp_path):
 @pytest.mark.parametrize("argument", ["model", "custom_model", "auth_model"])
 @pytest.mark.parametrize("prefix", ["", "openai/", "openai-codex/"])
 def test_unsupported_chatgpt_models_fail_locally(tmp_path, model, argument, prefix):
-    with pytest.raises(ValueError, match="not supported.*gpt-5.5"):
+    with pytest.raises(ValueError, match="not supported.*gpt-6-astra"):
         OpenAIOAuth(
             **{argument: prefix + model},
             oauth_credential_path=str(tmp_path / "auth.json"),

--- a/tests/test_openai_oauth_llm.py
+++ b/tests/test_openai_oauth_llm.py
@@ -358,3 +358,60 @@ def test_gpt_6_astra_async_request_uses_exact_model_and_reasoning(
             "reasoning": {"effort": "low"},
         }
     ]
+
+
+def test_oauth_implicit_default_matches_catalog(tmp_path):
+    llm = OpenAIOAuth(oauth_credential_path=str(tmp_path / "auth.json"))
+    assert (
+        llm.model
+        == resolve_provider_variant("openai", "oauth").default_model
+        == "gpt-5.5"
+    )
+
+
+@pytest.mark.parametrize("model", ["gpt-5.4", "gpt-5.4-mini"])
+@pytest.mark.parametrize("argument", ["model", "custom_model", "auth_model"])
+@pytest.mark.parametrize("prefix", ["", "openai/", "openai-codex/"])
+def test_unsupported_chatgpt_models_fail_locally(tmp_path, model, argument, prefix):
+    with pytest.raises(ValueError, match="not supported.*gpt-5.5"):
+        OpenAIOAuth(
+            **{argument: prefix + model},
+            oauth_credential_path=str(tmp_path / "auth.json"),
+        )
+
+
+@pytest.mark.parametrize("model", ["gpt-5.5", "gpt-6-astra"])
+@pytest.mark.parametrize("async_call", [False, True])
+def test_oauth_structured_extraction_prompts_for_schema(
+    tmp_path, monkeypatch, model, async_call
+):
+    from llama_index.core.base.llms.types import ChatResponse
+    from llama_index.core.prompts import PromptTemplate
+    from pydantic import BaseModel
+
+    class Result(BaseModel):
+        value: int
+
+    captured = []
+    llm = _offline_oauth_llm(tmp_path, model=model)
+
+    def chat(_self, messages, **kwargs):
+        captured.extend(messages)
+        return ChatResponse(
+            message=ChatMessage(role=MessageRole.ASSISTANT, content='{"value":19}')
+        )
+
+    async def achat(_self, messages, **kwargs):
+        return chat(_self, messages, **kwargs)
+
+    monkeypatch.setattr(type(llm), "chat", chat)
+    monkeypatch.setattr(type(llm), "achat", achat)
+    prompt = PromptTemplate("Return 8 plus 11 as value.")
+    result = (
+        asyncio.run(llm.astructured_predict(Result, prompt))
+        if async_call
+        else llm.structured_predict(Result, prompt)
+    )
+    assert result.value == 19
+    assert '"properties"' in "\n".join(str(m.content) for m in captured)
+    assert '"value"' in "\n".join(str(m.content) for m in captured)

--- a/tests/test_provider_defaults.py
+++ b/tests/test_provider_defaults.py
@@ -1,0 +1,224 @@
+"""Default selection and reasoning at the provider SDK request boundary."""
+
+import asyncio
+import json
+from dataclasses import asdict
+
+import pytest
+
+try:
+    from openai._base_client import httpx2 as httpx
+except ImportError:
+    import httpx
+from llama_index.core.llms import ChatMessage
+
+from mobilerun.agent.providers.registry import resolve_provider_variant
+from mobilerun.agent.providers.setup_service import (
+    SetupSelection,
+    create_profile_for_variant,
+)
+from mobilerun.agent.utils.llm_picker import load_llm
+
+
+def _credentials(family, auth, tmp_path):
+    if auth == "api_key":
+        if family == "gemini":
+            # Avoid the adapter's model-catalog request in an offline test.
+            return {"api_key": "stub", "context_window": 1_000_000, "max_tokens": 1024}
+        return {"api_key": "stub"}
+    path = str(tmp_path / "credentials.json")
+    if family == "openai":
+        return {
+            "oauth_access_token": "stub",
+            "oauth_expires_at_ms": 4_102_444_800_000,
+            "oauth_credential_path": path,
+        }
+    return {"credential_path": path}
+
+
+@pytest.mark.parametrize(
+    "family,auth,expected",
+    [
+        ("openai", "api_key", "gpt-6-astra"),
+        ("openai", "oauth", "gpt-6-astra"),
+        ("gemini", "api_key", "gemini-3.8-flash"),
+        ("gemini", "oauth", "gemini-3.8-flash-tiered"),
+        ("anthropic", "api_key", "claude-sonnet-5"),
+        ("anthropic", "oauth", "claude-sonnet-5"),
+    ],
+)
+def test_defaults_agree_across_menu_loader_and_generated_profile(
+    family, auth, expected, tmp_path
+):
+    variant = resolve_provider_variant(family, auth)
+    assert variant.default_model == variant.models[0] == expected
+    assert len(variant.models) == len(set(variant.models))
+    credentials = _credentials(family, auth, tmp_path)
+    implicit = load_llm(variant.runtime_provider_name, **credentials)
+    assert implicit.model == expected
+    profile = create_profile_for_variant(
+        variant,
+        SetupSelection(
+            family_id=family,
+            variant_id=variant.id,
+            auth_mode=auth,
+            model=variant.default_model,
+            credential_path=str(tmp_path / "credentials.json"),
+        ),
+    )
+    restored = type(profile)(**asdict(profile))
+    assert restored.model == expected
+    llm = load_llm(
+        restored.provider, model=restored.model, **{**restored.kwargs, **credentials}
+    )
+    assert llm.model == expected
+    if family == "openai":
+        payload = (
+            llm._get_model_kwargs()
+            if auth == "api_key"
+            else llm._sanitize_gpt_6_astra_kwargs({})
+        )
+        assert payload["reasoning"] == {"effort": "low"}
+
+
+@pytest.mark.parametrize("auth", ["api_key", "oauth"])
+@pytest.mark.parametrize("async_call", [False, True])
+@pytest.mark.parametrize(
+    "source,expected",
+    [
+        ("default", {"effort": "low"}),
+        ("constructor", {"effort": "high"}),
+        ("additional", {"effort": "xhigh"}),
+        ("runtime", {"effort": "max"}),
+        ("runtime_null", None),
+        ("runtime_summary", {"summary": "auto"}),
+    ],
+)
+def test_openai_default_and_explicit_reasoning_in_sdk_body(
+    auth, async_call, source, expected, tmp_path
+):
+    bodies = []
+
+    def respond(request):
+        body = json.loads(request.content)
+        bodies.append(body)
+        response = {
+            "id": "resp_test",
+            "object": "response",
+            "created_at": 0,
+            "model": "gpt-6-astra",
+            "status": "completed",
+            "usage": {
+                "input_tokens": 1,
+                "output_tokens": 1,
+                "total_tokens": 2,
+                "input_tokens_details": {"cached_tokens": 0},
+                "output_tokens_details": {"reasoning_tokens": 0},
+            },
+            "output": [
+                {
+                    "id": "msg_test",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [
+                        {"type": "output_text", "text": "READY", "annotations": []}
+                    ],
+                }
+            ],
+        }
+        if body.get("stream"):
+            events = [
+                {"type": "response.output_text.delta", "delta": "READY"},
+                {"type": "response.completed", "response": response},
+            ]
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                text="".join(f"data: {json.dumps(event)}\n\n" for event in events),
+            )
+        return httpx.Response(200, json=response)
+
+    options = _credentials("openai", auth, tmp_path)
+    if source != "default":
+        if auth == "api_key":
+            options["reasoning_options"] = {"effort": "high"}
+        else:
+            options["reasoning_effort"] = "high"
+    if source not in {"default", "constructor"}:
+        options["additional_kwargs"] = {"reasoning": {"effort": "xhigh"}}
+    runtime = {"reasoning": expected} if source.startswith("runtime") else {}
+    sync_client = httpx.Client(transport=httpx.MockTransport(respond))
+    async_client = httpx.AsyncClient(transport=httpx.MockTransport(respond))
+    llm = load_llm(
+        resolve_provider_variant("openai", auth).runtime_provider_name,
+        http_client=sync_client,
+        async_http_client=async_client,
+        **options,
+    )
+    messages = [ChatMessage(role="user", content="Reply READY")]
+
+    async def run():
+        try:
+            if async_call:
+                return await llm.achat(messages, **runtime)
+            return llm.chat(messages, **runtime)
+        finally:
+            sync_client.close()
+            await async_client.aclose()
+
+    result = asyncio.run(run())
+    assert result.message.content == "READY"
+    assert len(bodies) == 1
+    assert bodies[0]["model"] == "gpt-6-astra"
+    assert bodies[0].get("reasoning") == expected
+    assert {"temperature", "top_p", "logprobs", "top_logprobs"}.isdisjoint(bodies[0])
+
+
+@pytest.mark.parametrize("auth", ["api_key", "oauth"])
+@pytest.mark.parametrize("model", ["gpt-5.5", "gpt-5.6-luna"])
+def test_previous_openai_models_have_no_new_reasoning_default(auth, model, tmp_path):
+    llm = load_llm(
+        resolve_provider_variant("openai", auth).runtime_provider_name,
+        model=model,
+        **_credentials("openai", auth, tmp_path),
+    )
+    payload = (
+        llm._get_model_kwargs()
+        if auth == "api_key"
+        else llm._sanitize_gpt_6_astra_kwargs({})
+    )
+    assert llm.model == model
+    assert "reasoning" not in payload
+
+
+@pytest.mark.parametrize("family", ["gemini", "anthropic", "openai"])
+def test_login_helpers_use_current_oauth_defaults(family, tmp_path, monkeypatch):
+    from mobilerun.cli import oauth_actions
+
+    classes = {
+        "gemini": oauth_actions.GeminiOAuthCodeAssistLLM,
+        "anthropic": oauth_actions.AnthropicOAuthLLM,
+        "openai": oauth_actions.OpenAIOAuth,
+    }
+    selected = []
+
+    def login(self, **kwargs):
+        selected.append(self.model)
+        return "stub-token"
+
+    monkeypatch.setattr(classes[family], "login", login)
+    path = str(tmp_path / "credentials.json")
+    if family == "gemini":
+        monkeypatch.setattr(
+            classes[family], "fetch_available_models", lambda *a, **kw: [{}]
+        )
+        monkeypatch.setattr(
+            classes[family], "_persist_credentials", lambda *a, **kw: None
+        )
+        oauth_actions.run_gemini_oauth_login(path, None)
+    elif family == "openai":
+        oauth_actions.run_openai_oauth_login(path, None)
+    else:
+        oauth_actions.run_anthropic_oauth_setup(path)
+    assert selected == [resolve_provider_variant(family, "oauth").default_model]

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -32,13 +32,11 @@ def test_gemini_oauth_catalog_uses_antigravity_consumer_models() -> None:
     variant = resolve_provider_variant("gemini", "oauth")
     models = list_models_for_variant("gemini", "oauth")
 
-    assert variant.default_model == "gemini-3.5-flash-low"
+    assert variant.default_model == "gemini-3.7-flash-tiered"
     assert models == (
-        "gemini-3.5-flash-low",
-        "gemini-3.8-flash-tiered",
         "gemini-3.7-flash-tiered",
-        "gemini-3.5-flash-extra-low",
-        "gemini-3-flash-agent",
+        "gemini-3.8-flash-tiered",
+        "gemini-3.5-flash-lite",
         "gemini-3-flash",
         "gemini-pro-agent",
         "gemini-3.1-pro-low",
@@ -131,8 +129,6 @@ def test_openai_oauth_catalog_hides_unsupported_codex_model() -> None:
         "gpt-5.6-sol",
         "gpt-5.6-terra",
         "gpt-5.6-luna",
-        "gpt-5.4",
-        "gpt-5.4-mini",
     )
     assert "gpt-5.3-codex" not in models
 

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -14,10 +14,10 @@ def test_gemini_api_key_catalog_uses_current_flash_models() -> None:
     models = list_models_for_variant("gemini", "api_key")
 
     assert models[0] == variant.default_model == LLMProfile().model
-    assert variant.default_model == "gemini-3.7-flash"
+    assert variant.default_model == "gemini-3.8-flash"
     assert models == (
-        "gemini-3.7-flash",
         "gemini-3.8-flash",
+        "gemini-3.7-flash",
         "gemini-3.5-flash",
         "gemini-3.6-flash",
         "gemini-3.5-flash-lite",
@@ -32,10 +32,10 @@ def test_gemini_oauth_catalog_uses_antigravity_consumer_models() -> None:
     variant = resolve_provider_variant("gemini", "oauth")
     models = list_models_for_variant("gemini", "oauth")
 
-    assert variant.default_model == "gemini-3.7-flash-tiered"
+    assert variant.default_model == "gemini-3.8-flash-tiered"
     assert models == (
-        "gemini-3.7-flash-tiered",
         "gemini-3.8-flash-tiered",
+        "gemini-3.7-flash-tiered",
         "gemini-3.5-flash-lite",
         "gemini-3-flash",
         "gemini-pro-agent",
@@ -87,29 +87,29 @@ def test_model_display_names_preserve_canonical_ids_except_explicit_overrides(
     assert model_display_name_for_variant(family_id, auth_mode, model_id) == expected
 
 
-def test_anthropic_catalogs_include_claude_5_without_changing_defaults() -> None:
+def test_anthropic_catalogs_default_to_sonnet_5_and_retain_older_models() -> None:
     api_key_variant = resolve_provider_variant("anthropic", "api_key")
     api_key_models = list_models_for_variant("anthropic", "api_key")
     oauth_variant = resolve_provider_variant("anthropic", "oauth")
     oauth_models = list_models_for_variant("anthropic", "oauth")
 
-    assert api_key_variant.default_model == "claude-sonnet-4-6"
+    assert api_key_variant.default_model == "claude-sonnet-5"
     assert api_key_models == (
-        "claude-sonnet-4-6",
+        "claude-sonnet-5",
         "claude-fable-5-1",
         "claude-opus-5",
-        "claude-sonnet-5",
+        "claude-sonnet-4-6",
         "claude-fable-5",
         "claude-opus-4-8",
         "claude-opus-4-6",
         "claude-haiku-4-5",
     )
-    assert oauth_variant.default_model == "claude-opus-4-7"
+    assert oauth_variant.default_model == "claude-sonnet-5"
     assert oauth_models == (
-        "claude-opus-4-7",
+        "claude-sonnet-5",
         "claude-fable-5-1",
         "claude-opus-5",
-        "claude-sonnet-5",
+        "claude-opus-4-7",
         "claude-fable-5",
         "claude-opus-4-8",
         "claude-sonnet-4-6",
@@ -122,10 +122,10 @@ def test_openai_oauth_catalog_hides_unsupported_codex_model() -> None:
     variant = resolve_provider_variant("openai", "oauth")
     models = list_models_for_variant("openai", "oauth")
 
-    assert variant.default_model == "gpt-5.5"
+    assert variant.default_model == "gpt-6-astra"
     assert models == (
-        "gpt-5.5",
         "gpt-6-astra",
+        "gpt-5.5",
         "gpt-5.6-sol",
         "gpt-5.6-terra",
         "gpt-5.6-luna",
@@ -137,10 +137,10 @@ def test_openai_api_key_catalog_uses_current_default_model() -> None:
     variant = resolve_provider_variant("openai", "api_key")
     models = list_models_for_variant("openai", "api_key")
 
-    assert variant.default_model == "gpt-5.5"
+    assert variant.default_model == "gpt-6-astra"
     assert models == (
-        "gpt-5.5",
         "gpt-6-astra",
+        "gpt-5.5",
         "gpt-5.6-sol",
         "gpt-5.6-terra",
         "gpt-5.6-luna",
@@ -150,12 +150,12 @@ def test_openai_api_key_catalog_uses_current_default_model() -> None:
     )
 
 
-def test_default_profiles_use_gemini_3_7_flash() -> None:
+def test_default_profiles_use_gemini_3_8_flash() -> None:
     config = MobileConfig()
 
-    assert LLMProfile().model == "gemini-3.7-flash"
+    assert LLMProfile().model == "gemini-3.8-flash"
     assert {profile.model for profile in config.llm_profiles.values()} == {
-        "gemini-3.7-flash"
+        "gemini-3.8-flash"
     }
 
 


### PR DESCRIPTION
Gemini OAuth previously selected a retired model, some OAuth menu choices no longer accepted requests, and provider compatibility bugs prevented successful calls or structured extraction. Refresh the defaults, remove only confirmed unavailable choices for their authentication route, and fix those request compatibility bugs.

## Current defaults

| Provider | API | OAuth |
| --- | --- | --- |
| OpenAI | `gpt-6-astra`, reasoning `low` | `gpt-6-astra`, reasoning `low` |
| Gemini | `gemini-3.8-flash` | `gemini-3.8-flash-tiered` |
| Anthropic | `claude-sonnet-5` | `claude-sonnet-5` |

Defaults agree across configuration menus, generated profiles, model-less loaders, OAuth constructors/login helpers, and Gemini's `flash` preset. GPT-6 receives `low` only when no explicit reasoning setting is supplied; configuration and per-call override precedence is preserved. Older working models remain selectable, including GPT-5.6 Luna, GPT-5.5, Gemini 3.7, Sonnet 4.6, and OAuth Opus 4.7. Saved model selections and credentials are unchanged; no automatic model fallback is added.

## Other fixes

- Filter retired Gemini OAuth IDs `gemini-3.5-flash-low`, `gemini-3.5-flash-extra-low`, and `gemini-3-flash-agent` from menus and discovery, and reject explicit selections with a reconfiguration error. `flash_lite` uses verified `gemini-3.5-flash-lite`.
- Remove OpenAI OAuth `gpt-5.4` and `gpt-5.4-mini` after repeated unsupported-with-ChatGPT-account errors and a successful control. Keep their working API choices.
- Adapt Anthropic sampling controls to SDK 1.x through `extra_body`, preserve older SDK behavior/override precedence, and remove rejected controls from the final body. Correct structured tool-choice formatting while preserving signature introspection.
- Route Anthropic/OpenAI OAuth structured extraction through validated text programs supported by these adapters.

## Live provider validation — September 10, 2026

The initial audit passed text, structured output, and screenshot reading for **46 retained model/auth combinations (138 checks)**. After the default update, all **six new implicit defaults passed all three checks again (18/18)**. Gemini and Anthropic OAuth also passed these checks using the configuration-generated 1,024-token limit. The full retained catalog was not re-audited after the default-only update.

Default streaming passed **4/6** again. Existing limitations remain: Anthropic OAuth raises `NotImplementedError`; OpenAI OAuth's inherited streaming route returns HTTP 403. Both were reproduced on unchanged main with working ordinary-call controls. No fresh interactive authorization was initiated.

Sources: [OpenAI GPT-6 effort support](https://developers.openai.com/api/docs/models/gpt-6-astra), [Gemini 3.8](https://ai.google.dev/gemini-api/docs/models/gemini-3.8-flash), [Sonnet 5](https://platform.claude.com/docs/en/models/sonnet-5/whats-new-sonnet-5). The original retirement audit also checked [Google](https://ai.google.dev/gemini-api/docs/deprecations), [Anthropic](https://platform.claude.com/docs/en/about-claude/model-deprecations), and [OpenAI](https://developers.openai.com/api/docs/deprecations) lifecycle documentation alongside live catalogs and inference.

## Fresh Android end-to-end results

**10/10 passed** using the new implicit defaults on Android 16, `Medium_Phone_API_36.1`, Portal 0.7.25. Runs were sequential with indexed tapping, coordinate-click tools disabled, streaming disabled, and limits of 15 steps / 180 seconds. OpenAI requests used default `low` reasoning.

| Provider / authentication | Model | Scenario | Steps | Duration | Result |
| --- | --- | --- | --- | --- | --- |
| gemini / oauth | `gemini-3.8-flash-tiered` | Settings → Apps → Portal app info | 6 | 38.94s | Pass |
| gemini / oauth | `gemini-3.8-flash-tiered` | Settings search → Display & touch | 4 | 27.13s | Pass |
| gemini / oauth | `gemini-3.8-flash-tiered` | Parent, child, partially covered target, covering button | 5 | 26.77s | Pass |
| gemini / oauth | `gemini-3.8-flash-tiered` | Stealth tap and focusable/non-focusable popups | 6 | 31.64s | Pass |
| gemini / oauth | `gemini-3.8-flash-tiered` | Blocked tap → dismiss blocker → retry | 4 | 27.21s | Pass |
| gemini / api_key | `gemini-3.8-flash` | Settings search → Display & touch | 4 | 27.52s | Pass |
| anthropic / api_key | `claude-sonnet-5` | Settings search → Display & touch | 4 | 28.39s | Pass |
| anthropic / oauth | `claude-sonnet-5` | Settings search → Display & touch | 4 | 27.99s | Pass |
| openai / api_key | `gpt-6-astra` | Settings search → Display & touch | 4 | 33.28s | Pass |
| openai / oauth | `gpt-6-astra` | Settings search → Display & touch | 4 | 36.00s | Pass |

Raw trees, screenshots, handler markers, and driver traces independently verified outcomes. The intentionally blocked click dispatched zero taps, delivered its error to the LLM, and succeeded after the covering sibling was dismissed. Settings search required fresh text entry and independently verified Display & touch.

These are ten fresh runs after changing the defaults. The earlier ten successful runs used Gemini 3.7, GPT-5.5, API Sonnet 4.6, and OAuth Opus 4.7; their evidence remains separate. The local Settings task-reset correction from those earlier runs was reused.

## Repository checks

- Focused provider/OAuth/CLI tests: **494 passed in 3.81s**.
- Full suite: **962 passed, 3 subtests passed, 4 failed in 23.64s**. The same four failures reproduced on unchanged main: **875 passed, 3 subtests passed, 4 failed in 22.78s**. No new failing test cases.
- Existing failures: three SDK wire/mock-transport tests in `test_grok_api.py`, plus the native-media export test in `test_langfuse_v4.py`.
- Black **26.5.1**, **185 files clean**; Ruff on changed Python files and `git diff --check` passed.

No root README, `agent-test-flows`, fixtures, credentials, scripts, screenshots, or logs are committed. Related: #443 (already merged).
