### PR TITLE
chore: release mobilerun 0.6.19

### DIFF
--- a/compat/pyproject.toml
+++ b/compat/pyproject.toml
@@ -1,15 +1,15 @@
 [project]
 name = "droidrun"
-version = "0.6.18"
+version = "0.6.19"
 description = "Compatibility shim — droidrun has been renamed to mobilerun"
 requires-python = ">=3.11,<3.14"
-dependencies = ["mobilerun==0.6.18"]
+dependencies = ["mobilerun==0.6.19"]
 
 [project.optional-dependencies]
-anthropic = ["mobilerun[anthropic]==0.6.18"]
-deepseek = ["mobilerun[deepseek]==0.6.18"]
-langfuse = ["mobilerun[langfuse]==0.6.18"]
-dev = ["mobilerun[dev]==0.6.18"]
+anthropic = ["mobilerun[anthropic]==0.6.19"]
+deepseek = ["mobilerun[deepseek]==0.6.19"]
+langfuse = ["mobilerun[langfuse]==0.6.19"]
+dev = ["mobilerun[dev]==0.6.19"]
 
 [project.scripts]
 droidrun = "droidrun.cli_shim:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mobilerun"
-version = "0.6.18"
+version = "0.6.19"
 description = "A framework for controlling mobile devices through LLM agents"
 authors = [{ name = "Niels Schmidt", email = "niels@droidrun.ai" }]
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -1684,7 +1684,7 @@ wheels = [
 
 [[package]]
 name = "mobilerun"
-version = "0.6.18"
+version = "0.6.19"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Prepare Mobilerun **0.6.19** with the fixes merged in #442–#445. Align the root package, compatibility-shim version, and all five shim dependency pins at `0.6.19`; update only the lockfile's own-package version. All locked dependency versions are preserved.

Portal compatibility was merged in https://github.com/droidrun/gists/pull/1: exact mapping `0.6.19` → `0.7.25`, preserving every existing mapping. The public installed-package resolver returned Portal 0.7.25 after CDN propagation.

## Included release changes

- #442: bound agent finalization waits, preserve task results, and restore extraction traces.
- #443: honor manual OAuth selection and avoid known sibling obstructions during indexed Android taps; fully covered targets return actionable errors without dispatching taps.
- #444: default to GPT-6 Astra with low reasoning, Gemini 3.8, and Sonnet 5; remove confirmed retired Gemini OAuth choices and repair provider request compatibility.
- #445: normalize writable export copies before Langfuse media processing while preserving original ended spans and a single export/upload pipeline; update OpenAI SDK usage fixtures.

## Validation

Python 3.13.9, macOS ARM64. Source changes are limited to three versioning files; no README, agent-test-flows, credentials, fixture, or evidence files are included.

- Guide unittest discovery: **89 tests passed** (0.356s).
- Locked full suite: **978 passed + 3 subtests** (24.13s).
- Fresh runtime dependencies, installed release wheel, repository-locked pytest 9.0.3: **978 passed + 3 subtests** (18.78s).
- Focused tracing/provider/CLI matrix (`test_langfuse_v4`, `test_grok_api`, `test_phoenix_tracing`, `test_provider_defaults`, `test_openai_oauth_llm`, `test_grok_cli`):

| OpenTelemetry SDK/API | OpenAI SDK | Result | Duration |
|---|---|---|---:|
| 1.40.0 | 2.30.0 | 175 passed | 2.98s |
| 1.40.0 | 2.54.0 | 175 passed | 38.95s |
| 1.44.0 | 2.30.0 | 175 passed | 38.04s |
| 1.44.0 | 2.54.0 | 175 passed | 40.22s |

Langfuse was 4.15.1 in all environments. Fresh runtime resolution also used Anthropic 1.5.0, google-genai 2.22.0, mobilerun-sdk 5.4.0, mobilerun-core-local 0.6.0, llama-index 0.14.23, and llama-index-llms-google-genai 0.11.1. Exact complete manifests are retained outside the repositories.

- Black **26.5.1**: 185 files unchanged. Ruff checks on Python files changed since v0.6.18 passed. `git diff --check` passed in both repositories.
- Built wheels and source distributions for both packages. Twine checks passed; the shim retains pre-existing missing-long-description warnings.
- Clean installed-wheel environments verified `site-packages` imports, package versions, public APIs, all six defaults, and `mobilerun`/`droidrun` CLI entry points. Installing the built `droidrun[anthropic]` wheel against the built Mobilerun wheel resolved correctly; all five shipped shim pins are exact. Dependency checks passed in all seven environments.
- Real installed Portal resolver, with the proposed map supplied locally: `0.6.19` resolves to `0.7.25`; `0.6.8` and `0.6.18` still resolve to `0.7.22`.

## Android end-to-end results

Restarted `Medium_Phone_API_36.1`, verified Android **16** and Portal **0.7.25**. Ten sequential real `MobileAgent` sessions used the **installed release wheel with freshly resolved runtime dependencies**, saved credentials, implicit provider defaults, indexed tapping, a 15-step limit and a 180-second agent timeout. Destinations and handler markers were checked independently from the model's completion message; selected indices, coordinates, raw trees, screenshots and action logs are retained externally.

| Provider / auth | Implicit model | Scenario | Steps | Duration | Result |
|---|---|---|---:|---:|---|
| Gemini / OAUTH | `gemini-3.8-flash-tiered` | Portal app information | 6 | 52.03s | PASS |
| Gemini / OAUTH | `gemini-3.8-flash-tiered` | Settings search → Display & touch | 4 | 30.12s | PASS |
| Gemini / OAUTH | `gemini-3.8-flash-tiered` | Decorative parent, clickable child, overlapping targets | 5 | 30.90s | PASS |
| Gemini / OAUTH | `gemini-3.8-flash-tiered` | Stealth tapping; focusable and non-focusable popups | 6 | 31.54s | PASS |
| Gemini / OAUTH | `gemini-3.8-flash-tiered` | Blocked target, error feedback, dismissal and retry | 4 | 27.69s | PASS |
| Gemini / API | `gemini-3.8-flash` | Settings search → Display & touch | 4 | 29.86s | PASS |
| Anthropic / API | `claude-sonnet-5` | Settings search → Display & touch | 4 | 28.97s | PASS |
| Anthropic / OAUTH | `claude-sonnet-5` | Settings search → Display & touch | 4 | 27.04s | PASS |
| Openai / API | `gpt-6-astra` | Settings search → Display & touch | 4 | 31.36s | PASS |
| Openai / OAUTH | `gpt-6-astra` | Settings search → Display & touch | 4 | 41.05s | PASS |

Gemini OAuth Settings search used the real Langfuse SDK with local export capture and mocked upload I/O: **36 unique exported spans, 5 screenshot spans, 5 valid media references and exactly 5 upload jobs**. Original spans remained unchanged; one owned Langfuse pipeline, no duplicate exports and no normalization errors were observed. This verifies SDK transformation and queuing, not a hosted Langfuse dashboard or external upload service.

Installed-wheel CLI checks passed: device discovery (1.20s), ping (2.14s), and the guide's screen-report smoke with a two-step limit (one step, 10.25s). The agent reported Settings and called only `complete(success=True)`; independent before/after trees confirmed the same Settings screen.

## Test setup observations

The first fully fresh test run with pytest **9.1.1** produced 977 passes and one warning-count assertion failure. A standalone reproduction with **no Mobilerun imports** proved that pytest attaches the same capture handler twice when a logger switches propagation, capturing one `LogRecord` twice. Rerunning with the repository-locked pytest **9.0.3** passed the full suite; every freshly resolved runtime package was identical. No tests were skipped or weakened and no dependency pins were changed.

The initial CLI smoke configuration omitted `_version` and was correctly rejected before agent startup. The external harness was corrected to use the installed config format version and rerun. This was a test setup error.

Publication and post-publication checks are complete; results follow.

## Publication and post-publication verification

Released as https://github.com/droidrun/mobilerun/releases/tag/v0.6.19 at merge commit `0837a7ddbd537d91f818d614a0f9ada20e4c6a6e` with an annotated tag.

- Publishing workflow https://github.com/droidrun/mobilerun/actions/runs/34512527715 passed all four jobs: version check, both-package build, TestPyPI, and PyPI.
- Both packages have 0.6.19 wheels and source distributions on TestPyPI and PyPI. All four published artifacts have identical SHA-256 hashes to the locally validated builds.
- Fresh public-PyPI installations of `mobilerun==0.6.19`, `droidrun==0.6.19`, and `droidrun[anthropic]==0.6.19` passed installed import/API/CLI/version checks and dependency checks. All five shim pins are 0.6.19; the Anthropic extra resolves correctly.
- Each public installation resolves Mobilerun 0.6.19 to Portal 0.7.25 using the live public mapping.
- Final Android 16 smoke from the clean PyPI-installed Mobilerun package passed: device discovery 1.76s, ping 2.17s, and Settings screen-report task 10.46s / one step within the two-step limit. Only `complete(success=True)` ran, and independent before/after trees confirmed Settings.

Package pages: https://pypi.org/project/mobilerun/0.6.19/ and https://pypi.org/project/droidrun/0.6.19/.
