### PR TITLE
feat: add Requesty as an OpenAI-compatible provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@
 </p>
 
 - 🤖 Control Android and iOS devices with natural language commands
-- 🔀 Use OpenAI, Anthropic, Gemini, xAI, Ollama, DeepSeek, OpenRouter, and OpenAI-compatible models
+- 🔀 Use OpenAI, Anthropic, Gemini, xAI, Ollama, DeepSeek, OpenRouter, Requesty, and OpenAI-compatible models
 - 🧠 Run direct tasks or enable reasoning mode for complex multi-step automation
 - 💻 Automate from the CLI, a terminal UI, Docker, or Python code
 - 🐍 Extend agents with custom tools, structured output, app cards, and credentials
@@ -114,7 +114,7 @@ You should see confirmation that the Portal is installed and accessible.
 mobilerun configure
 ```
 
-The wizard walks you through choosing a provider, auth method, and model. You can also use provider environment variables such as `GOOGLE_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `XAI_API_KEY`, or `MINIMAX_API_KEY`.
+The wizard walks you through choosing a provider, auth method, and model. You can also use provider environment variables such as `GOOGLE_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `XAI_API_KEY`, `MINIMAX_API_KEY`, or `REQUESTY_API_KEY`.
 
 ### 4. Run your first command
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -11,7 +11,7 @@ It enables mobile automation using natural language commands.
 - **GitHub**: https://github.com/droidrun/mobilerun
 - **Docs site**: https://docs.mobilerun.ai
 - **License**: MIT
-- **Install**: `uv tool install mobilerun` (Google Gemini, OpenAI, DeepSeek, Ollama, OpenRouter included by default)
+- **Install**: `uv tool install mobilerun` (Google Gemini, OpenAI, DeepSeek, Ollama, OpenRouter, Requesty included by default)
 - **Optional extras**: `anthropic`, `langfuse`
 - **Requires**: Python 3.11+, ADB, Portal APK on device
 

--- a/docs/guides/cli.mdx
+++ b/docs/guides/cli.mdx
@@ -121,6 +121,12 @@ mobilerun run "Open Settings" \
   --model MiniMax-M3 \
   --base_url https://api.minimax.io/v1
 
+# Requesty (one API across 700+ models)
+export REQUESTY_API_KEY=your-key
+mobilerun run "Open Settings" \
+  --provider Requesty \
+  --model openai/gpt-4o-mini
+
 # Local Ollama (free)
 mobilerun run "Turn on dark mode" \
   --provider Ollama \
@@ -163,6 +169,7 @@ mobilerun run "Enable 2FA" \
 | XAI | Included by default | `XAI_API_KEY` |
 | OpenAILike | Included by default | Varies by provider |
 | OpenRouter | Included by default | `OPENROUTER_API_KEY` |
+| Requesty | Included by default | `REQUESTY_API_KEY` |
 | Ollama | Included by default | None (local) |
 | Anthropic | `uv pip install 'mobilerun[anthropic]'` | `ANTHROPIC_API_KEY` |
 | DeepSeek | Included by default | `DEEPSEEK_API_KEY` |
@@ -232,6 +239,38 @@ saved `apiKeys.minimax` entry in `credentials/auth-profiles.json` inside
 Mobilerun's platform configuration directory. Pasting a new key in the wizard
 updates that saved entry. The top-level `credentials.enabled` setting controls
 device secrets and does not configure LLM provider authentication.
+
+### Requesty endpoints and credentials
+
+Requesty is an LLM router that exposes one OpenAI-compatible API across 700+
+models. Get a key at https://app.requesty.ai/api-keys and set `REQUESTY_API_KEY`,
+or run `mobilerun configure`, choose Requesty, and paste the key. Model ids are
+either full `<vendor>/<model>` catalog ids (for example `openai/gpt-4o-mini`) or
+managed policy ids, which are short stable names for Requesty-maintained
+multi-provider routing chains (for example `claude-sonnet-5` or `gpt-5.4-mini`).
+Both lists are public: `GET https://router.requesty.ai/v1/models/managed` and
+`GET https://router.requesty.ai/v1/models`.
+
+| Region | Base URL |
+|--------|----------|
+| Global (default) | `https://router.requesty.ai/v1` |
+| EU (Frankfurt) | `https://router.eu.requesty.ai/v1` |
+| US | `https://router.us.requesty.ai/v1` |
+| AP | `https://router.ap.requesty.ai/v1` |
+
+The same key works on every region. Pick a region with the wizard's base URL
+prompt, with `--base-url`, or by setting `REQUESTY_BASE_URL`:
+
+```bash
+mobilerun configure \
+  --provider requesty \
+  --model openai/gpt-4o-mini \
+  --base-url https://router.eu.requesty.ai/v1
+```
+
+With `api_key_source: auto`, a key saved under `apiKeys.requesty` takes
+precedence over `REQUESTY_API_KEY`. Choose **Use env key** in the wizard to force
+the shell value. See https://docs.requesty.ai for the full API reference.
 
   </Tab>
 
@@ -585,6 +624,8 @@ mobilerun ping --tcp
 | `XAI_API_KEY` | xAI API key for Grok | None |
 | `DEEPSEEK_API_KEY` | DeepSeek API key | None |
 | `MINIMAX_API_KEY` | MiniMax API key | None |
+| `REQUESTY_API_KEY` | Requesty API key | None |
+| `REQUESTY_BASE_URL` | Requesty router URL override (for example the EU region) | `https://router.requesty.ai/v1` |
 | `MOBILERUN_CLOUD_API_KEY` | Mobilerun Cloud API key for `devices --cloud` and cloud device actions | None |
 | `MOBILERUN_CONFIG` | Config file path | `~/.config/mobilerun/config.yaml` |
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -56,7 +56,7 @@ uv pip install mobilerun
 ```
 
 <Note>
-Most LLM providers (Google Gemini, OpenAI, DeepSeek, Ollama, OpenRouter) are included by default. For additional providers, install extras: `uv tool install 'mobilerun[anthropic]'`.
+Most LLM providers (Google Gemini, OpenAI, DeepSeek, Ollama, OpenRouter, Requesty) are included by default. For additional providers, install extras: `uv tool install 'mobilerun[anthropic]'`.
 </Note>
 
 ### Set Up the Portal APK

--- a/docs/sdk/configuration.mdx
+++ b/docs/sdk/configuration.mdx
@@ -611,11 +611,11 @@ mobilerun run "Task" --config /path/to/config.yaml
 - `--config PATH` - Custom config file
 - `--device SERIAL` - Device serial/IP
 - `--agent NAME` - External agent to use. Not yet supported — reserved for future use.
-- `--provider PROVIDER` - LLM provider (OpenAI, XAI, Ollama, Anthropic, GoogleGenAI, DeepSeek, MiniMax)
+- `--provider PROVIDER` - LLM provider (OpenAI, XAI, Ollama, Anthropic, GoogleGenAI, DeepSeek, MiniMax, Requesty)
 - `--model MODEL` - LLM model name
 - `--temperature FLOAT` - LLM temperature
 - `--steps INT` - Max steps
-- `--base_url URL` - API base URL (for Ollama/OpenRouter/MiniMax)
+- `--base_url URL` - API base URL (for Ollama/OpenRouter/Requesty/MiniMax)
 - `--api_base URL` - API base URL (for OpenAI-like)
 - `--vision/--no-vision` - Enable/disable vision for all agents
 - `--reasoning/--no-reasoning` - Enable/disable reasoning mode
@@ -638,6 +638,7 @@ export ANTHROPIC_API_KEY=your-key
 export XAI_API_KEY=your-key
 export DEEPSEEK_API_KEY=your-key
 export MINIMAX_API_KEY=your-key
+export REQUESTY_API_KEY=your-key
 export MOBILERUN_CONFIG=/path/to/config.yaml  # Custom config path
 ```
 
@@ -663,6 +664,18 @@ entry. Keys pasted into the wizard are stored in the `apiKeys.minimax` entry of
 `credentials/auth-profiles.json` in the platform configuration directory; this
 file is separate from the device secrets file controlled by
 `credentials.enabled`.
+
+Requesty routes one OpenAI-compatible API across 700+ models. It uses
+`https://router.requesty.ai/v1` by default; set `REQUESTY_BASE_URL` or pass
+`--base-url https://router.eu.requesty.ai/v1` to route through the EU region.
+Model ids are `<vendor>/<model>` catalog ids or managed policy ids from
+`https://router.requesty.ai/v1/models/managed`:
+
+```bash
+mobilerun configure \
+  --provider requesty \
+  --model openai/gpt-4o-mini
+```
 
 ## Manual OAuth login
 

--- a/mobilerun/agent/providers/__init__.py
+++ b/mobilerun/agent/providers/__init__.py
@@ -13,6 +13,13 @@ from mobilerun.agent.providers.registry import (
     normalize_model_id_for_variant,
     resolve_provider_variant,
 )
+from mobilerun.agent.providers.requesty import (
+    REQUESTY_BASE_URL,
+    REQUESTY_DEFAULT_MODEL,
+    REQUESTY_EU_BASE_URL,
+    REQUESTY_MODELS,
+    resolve_requesty_base_url,
+)
 from mobilerun.agent.providers.types import (
     ProviderFamilySpec,
     ProviderVariantSpec,
@@ -22,6 +29,10 @@ __all__ = [
     "MINIMAX_CHINA_BASE_URL",
     "MINIMAX_GLOBAL_BASE_URL",
     "MINIMAX_LEGACY_BASE_URL",
+    "REQUESTY_BASE_URL",
+    "REQUESTY_DEFAULT_MODEL",
+    "REQUESTY_EU_BASE_URL",
+    "REQUESTY_MODELS",
     "VARIANT_ENV_KEY_SLOT",
     "ProviderFamilySpec",
     "ProviderVariantSpec",
@@ -31,5 +42,6 @@ __all__ = [
     "list_provider_families",
     "normalize_model_id_for_variant",
     "resolve_provider_variant",
+    "resolve_requesty_base_url",
     "warn_if_legacy_minimax_endpoint",
 ]

--- a/mobilerun/agent/providers/registry.py
+++ b/mobilerun/agent/providers/registry.py
@@ -13,6 +13,11 @@ from mobilerun.agent.providers.grok import (
     normalize_grok_model_id,
 )
 from mobilerun.agent.providers.minimax import MINIMAX_GLOBAL_BASE_URL
+from mobilerun.agent.providers.requesty import (
+    REQUESTY_BASE_URL,
+    REQUESTY_DEFAULT_MODEL,
+    REQUESTY_MODELS,
+)
 from mobilerun.agent.providers.types import (
     ProviderFamilySpec,
     ProviderVariantSpec,
@@ -34,6 +39,7 @@ VARIANT_ENV_KEY_SLOT: dict[str, str] = {
     "ZAI": "zai",
     "ZAI_Coding": "zai",
     "MiniMax": "minimax",
+    "Requesty": "requesty",
 }
 
 OPENAI_MODEL_ALIASES: dict[str, str] = {
@@ -273,6 +279,28 @@ PROVIDER_FAMILIES: tuple[ProviderFamilySpec, ...] = (
         notes=(
             "ZAI is exposed as a first-class provider family while reusing the OpenAI-compatible transport.",
             "Use auth mode `coding_api` for the GLM Coding Plan endpoint.",
+        ),
+    ),
+    ProviderFamilySpec(
+        id="requesty",
+        display_name="Requesty",
+        variants=(
+            ProviderVariantSpec(
+                id="Requesty",
+                runtime_provider_name="Requesty",
+                runtime_transport_provider_name="OpenAILike",
+                auth_mode="api_key",
+                default_model=REQUESTY_DEFAULT_MODEL,
+                models=REQUESTY_MODELS,
+                requires_api_key=True,
+                requires_base_url=True,
+                base_url=REQUESTY_BASE_URL,
+            ),
+        ),
+        notes=(
+            "Requesty is an LLM router with one OpenAI-compatible API across 700+ models.",
+            "Model ids are `<vendor>/<model>` catalog ids or managed policy ids from /v1/models/managed.",
+            "Set base_url to https://router.eu.requesty.ai/v1 to route through the EU region.",
         ),
     ),
 )

--- a/mobilerun/agent/providers/requesty.py
+++ b/mobilerun/agent/providers/requesty.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import os
+
+REQUESTY_BASE_URL = "https://router.requesty.ai/v1"
+REQUESTY_EU_BASE_URL = "https://router.eu.requesty.ai/v1"
+REQUESTY_US_BASE_URL = "https://router.us.requesty.ai/v1"
+REQUESTY_AP_BASE_URL = "https://router.ap.requesty.ai/v1"
+
+REQUESTY_API_KEY_ENV_VAR = "REQUESTY_API_KEY"
+REQUESTY_BASE_URL_ENV_VAR = "REQUESTY_BASE_URL"
+
+# Requesty accepts either a full "<vendor>/<model>" catalog id or a managed
+# policy id (a short, stable name for a Requesty-maintained routing chain).
+# Both come from the live catalog: GET /v1/models and GET /v1/models/managed.
+REQUESTY_DEFAULT_MODEL = "openai/gpt-4o-mini"
+REQUESTY_MODELS: tuple[str, ...] = (
+    REQUESTY_DEFAULT_MODEL,
+    "gpt-6-astra",
+    "gpt-5.4-mini",
+    "claude-sonnet-5",
+    "claude-haiku-4-5",
+    "gemini-3.8-flash",
+    "grok-4.6",
+)
+
+
+def resolve_requesty_base_url(base_url: str | None = None) -> str:
+    """Return the Requesty base URL to use.
+
+    An explicit ``base_url`` wins, then ``REQUESTY_BASE_URL`` (how users pick
+    a regional router such as the EU endpoint), then the global default.
+    """
+    if isinstance(base_url, str) and base_url.strip():
+        return base_url.strip()
+    env_base_url = os.environ.get(REQUESTY_BASE_URL_ENV_VAR, "")
+    if env_base_url.strip():
+        return env_base_url.strip()
+    return REQUESTY_BASE_URL

--- a/mobilerun/agent/utils/llm_picker.py
+++ b/mobilerun/agent/utils/llm_picker.py
@@ -32,6 +32,11 @@ from mobilerun.agent.providers.registry import (
     list_models_for_variant,
     normalize_model_id_for_variant,
 )
+from mobilerun.agent.providers.requesty import (
+    REQUESTY_API_KEY_ENV_VAR,
+    REQUESTY_DEFAULT_MODEL,
+    resolve_requesty_base_url,
+)
 from mobilerun.agent.usage import track_usage
 
 if TYPE_CHECKING:
@@ -49,6 +54,7 @@ SUPPORTED_PROVIDERS = [
     "Anthropic",
     "DeepSeek",
     "OpenRouter",
+    "Requesty",
     "MiniMax",
     "XAI",
 ]
@@ -67,6 +73,7 @@ PROVIDER_ALIASES = {
     "zai": "ZAI",
     "z.ai": "ZAI",
     "xai": "XAI",
+    "requesty": "Requesty",
 }
 
 ZAI_GLOBAL_API_BASE = "https://api.z.ai/api/paas/v4"
@@ -795,6 +802,27 @@ def load_llm(provider_name: str, model: str | None = None, **kwargs: Any) -> LLM
         if "base_url" in kwargs and "api_base" not in kwargs:
             kwargs["api_base"] = kwargs.pop("base_url")
         kwargs.setdefault("api_base", "https://api.deepseek.com")
+
+    if provider_name == "Requesty":
+        import os
+
+        api_key = kwargs.get("api_key")
+        if not isinstance(api_key, str) or not api_key.strip():
+            api_key = os.environ.get(REQUESTY_API_KEY_ENV_VAR)
+        if not isinstance(api_key, str) or not api_key.strip():
+            raise ValueError(
+                "Requesty requires an API key. Pass api_key explicitly or set "
+                f"{REQUESTY_API_KEY_ENV_VAR}."
+            )
+
+        provider_name = "OpenAILike"
+        kwargs["api_key"] = api_key
+        kwargs.setdefault("model", REQUESTY_DEFAULT_MODEL)
+        kwargs.setdefault("is_chat_model", True)
+        kwargs.setdefault("is_function_calling_model", True)
+        base_url = kwargs.pop("base_url", None)
+        if not kwargs.get("api_base"):
+            kwargs["api_base"] = resolve_requesty_base_url(base_url)
 
     # --- Standard providers (inline dispatch) ---
     if provider_name == "OpenAIResponses":

--- a/mobilerun/cli/main.py
+++ b/mobilerun/cli/main.py
@@ -473,7 +473,7 @@ except Exception:
 @click.option(
     "--provider",
     "-p",
-    help="LLM provider (OpenAI, openai_oauth, XAI, Ollama, Anthropic, anthropic_oauth, GoogleGenAI, gemini_oauth_code_assist, DeepSeek)",
+    help="LLM provider (OpenAI, openai_oauth, XAI, Ollama, Anthropic, anthropic_oauth, GoogleGenAI, gemini_oauth_code_assist, DeepSeek, Requesty)",
     default=None,
 )
 @click.option(
@@ -487,7 +487,7 @@ except Exception:
 @click.option(
     "--base_url",
     "-u",
-    help="Base URL for API (e.g., OpenRouter or Ollama)",
+    help="Base URL for API (e.g., OpenRouter, Requesty, or Ollama)",
     default=None,
 )
 @click.option(
@@ -1038,7 +1038,7 @@ async def doctor(device: str | None, debug: bool | None):
     "--provider",
     type=str,
     default=None,
-    help="Provider family (gemini, openai, anthropic, XAI, ollama, openai_like, minimax, zai).",
+    help="Provider family (gemini, openai, anthropic, XAI, ollama, openai_like, minimax, zai, requesty).",
 )
 @click.option(
     "--auth-mode",

--- a/mobilerun/config_manager/env_keys.py
+++ b/mobilerun/config_manager/env_keys.py
@@ -16,6 +16,7 @@ API_KEY_ENV_VARS = {
     "anthropic": "ANTHROPIC_API_KEY",
     "zai": "ZAI_API_KEY",
     "minimax": "MINIMAX_API_KEY",
+    "requesty": "REQUESTY_API_KEY",
 }
 
 _API_KEYS_SECTION = "apiKeys"

--- a/tests/test_requesty_configuration.py
+++ b/tests/test_requesty_configuration.py
@@ -1,0 +1,191 @@
+import pytest
+
+import mobilerun.config_manager.config_manager as config_manager_module
+from mobilerun.agent.providers.registry import (
+    VARIANT_ENV_KEY_SLOT,
+    resolve_provider_variant,
+)
+from mobilerun.agent.providers.requesty import (
+    REQUESTY_BASE_URL,
+    REQUESTY_DEFAULT_MODEL,
+    REQUESTY_EU_BASE_URL,
+    REQUESTY_MODELS,
+    resolve_requesty_base_url,
+)
+from mobilerun.agent.providers.setup_service import (
+    SetupSelection,
+    create_profile_for_variant,
+    family_choices,
+)
+from mobilerun.agent.utils.llm_picker import (
+    SUPPORTED_PROVIDERS,
+    load_llm,
+    normalize_provider_name,
+)
+from mobilerun.config_manager.config_manager import LLMProfile
+from mobilerun.config_manager.env_keys import API_KEY_ENV_VARS, ApiKeySources
+
+
+def test_requesty_registry_uses_global_router_endpoint() -> None:
+    variant = resolve_provider_variant("requesty", "api_key")
+
+    assert variant.id == "Requesty"
+    assert variant.runtime_transport_provider_name == "OpenAILike"
+    assert variant.base_url == REQUESTY_BASE_URL == "https://router.requesty.ai/v1"
+    assert variant.default_model == REQUESTY_DEFAULT_MODEL == "openai/gpt-4o-mini"
+    assert variant.models == REQUESTY_MODELS
+    assert variant.models[0] == variant.default_model
+    assert REQUESTY_EU_BASE_URL == "https://router.eu.requesty.ai/v1"
+
+
+def test_requesty_family_is_offered_by_the_configure_wizard() -> None:
+    assert "requesty" in {family.id for family in family_choices()}
+
+
+def test_requesty_env_key_slot_is_wired() -> None:
+    assert VARIANT_ENV_KEY_SLOT["Requesty"] == "requesty"
+    assert API_KEY_ENV_VARS["requesty"] == "REQUESTY_API_KEY"
+
+
+def test_requesty_is_a_supported_picker_provider() -> None:
+    assert "Requesty" in SUPPORTED_PROVIDERS
+    assert normalize_provider_name("requesty") == "Requesty"
+    assert normalize_provider_name("Requesty") == "Requesty"
+
+
+def test_requesty_setup_profile_uses_openai_like_transport() -> None:
+    variant = resolve_provider_variant("requesty", "api_key")
+    profile = create_profile_for_variant(
+        variant,
+        SetupSelection(
+            family_id="requesty",
+            variant_id=variant.id,
+            auth_mode="api_key",
+            model="claude-sonnet-5",
+            api_key_source="env",
+        ),
+    )
+
+    assert profile.provider == "OpenAILike"
+    assert profile.provider_family == "requesty"
+    assert profile.model == "claude-sonnet-5"
+    assert profile.base_url == REQUESTY_BASE_URL
+    assert profile.api_base == REQUESTY_BASE_URL
+    assert profile.kwargs == {}
+
+
+def test_requesty_setup_profile_keeps_regional_base_url_override() -> None:
+    variant = resolve_provider_variant("requesty", "api_key")
+    profile = create_profile_for_variant(
+        variant,
+        SetupSelection(
+            family_id="requesty",
+            variant_id=variant.id,
+            auth_mode="api_key",
+            model=REQUESTY_DEFAULT_MODEL,
+            api_key_source="env",
+            base_url=REQUESTY_EU_BASE_URL,
+        ),
+    )
+
+    assert profile.base_url == REQUESTY_EU_BASE_URL
+    assert profile.api_base == REQUESTY_EU_BASE_URL
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("env", "env-test-key"),
+        ("file", "saved-test-key"),
+        ("auto", "saved-test-key"),
+    ],
+)
+def test_openai_like_requesty_profile_resolves_configured_key_source(
+    monkeypatch, source: str, expected: str
+) -> None:
+    monkeypatch.setattr(
+        config_manager_module,
+        "load_env_key_sources",
+        lambda: {
+            "requesty": ApiKeySources(
+                shell="env-test-key",
+                saved="saved-test-key",
+            )
+        },
+    )
+    profile = LLMProfile(
+        provider="OpenAILike",
+        provider_family="requesty",
+        auth_mode="api_key",
+        model=REQUESTY_DEFAULT_MODEL,
+        api_key_source=source,
+        base_url=REQUESTY_BASE_URL,
+        api_base=REQUESTY_BASE_URL,
+    )
+
+    assert profile.to_load_llm_kwargs()["api_key"] == expected
+
+
+def test_requesty_alias_defaults_to_global_endpoint(monkeypatch) -> None:
+    monkeypatch.delenv("REQUESTY_BASE_URL", raising=False)
+
+    llm = load_llm("Requesty", api_key="stub")
+
+    assert type(llm).__name__ == "OpenAILike"
+    assert llm.api_base == REQUESTY_BASE_URL
+    assert llm.model == REQUESTY_DEFAULT_MODEL
+    assert llm.metadata.is_chat_model is True
+    assert llm.metadata.is_function_calling_model is True
+
+
+def test_requesty_alias_uses_requesty_environment_key(monkeypatch) -> None:
+    monkeypatch.setenv("REQUESTY_API_KEY", "requesty-env-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "wrong-openai-key")
+
+    llm = load_llm("Requesty", model="gpt-5.4-mini")
+
+    assert llm.api_key == "requesty-env-key"
+    assert llm.model == "gpt-5.4-mini"
+
+
+def test_requesty_alias_prefers_explicit_api_key(monkeypatch) -> None:
+    monkeypatch.setenv("REQUESTY_API_KEY", "requesty-env-key")
+
+    llm = load_llm("Requesty", api_key="explicit-requesty-key")
+
+    assert llm.api_key == "explicit-requesty-key"
+
+
+def test_requesty_alias_requires_an_api_key(monkeypatch) -> None:
+    monkeypatch.delenv("REQUESTY_API_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="REQUESTY_API_KEY"):
+        load_llm("Requesty", model=REQUESTY_DEFAULT_MODEL)
+
+
+def test_requesty_alias_honors_base_url_kwarg(monkeypatch) -> None:
+    monkeypatch.delenv("REQUESTY_BASE_URL", raising=False)
+
+    llm = load_llm("Requesty", api_key="stub", base_url=REQUESTY_EU_BASE_URL)
+
+    assert llm.api_base == REQUESTY_EU_BASE_URL
+
+
+def test_requesty_alias_honors_base_url_environment_override(monkeypatch) -> None:
+    monkeypatch.setenv("REQUESTY_BASE_URL", REQUESTY_EU_BASE_URL)
+
+    llm = load_llm("Requesty", api_key="stub")
+
+    assert llm.api_base == REQUESTY_EU_BASE_URL
+
+
+def test_resolve_requesty_base_url_precedence(monkeypatch) -> None:
+    monkeypatch.setenv("REQUESTY_BASE_URL", "https://router.us.requesty.ai/v1")
+
+    assert resolve_requesty_base_url("  https://router.ap.requesty.ai/v1 ") == (
+        "https://router.ap.requesty.ai/v1"
+    )
+    assert resolve_requesty_base_url("") == "https://router.us.requesty.ai/v1"
+
+    monkeypatch.delenv("REQUESTY_BASE_URL")
+    assert resolve_requesty_base_url(None) == REQUESTY_BASE_URL


### PR DESCRIPTION
## Summary

Adds Requesty (one OpenAI-compatible API across 700+ models from OpenAI, Anthropic, Google, xAI and others) as a provider. It follows the existing MiniMax / ZAI pattern: a first-class provider family that reuses the `OpenAILike` transport, plus a `load_llm` branch alongside OpenRouter and DeepSeek. That way `mobilerun configure` offers Requesty with a base URL prompt and a model menu without any wizard changes, since the wizard is registry driven.

## Changes

- New `mobilerun/agent/providers/requesty.py`: base URLs (global, EU, US, AP), `REQUESTY_API_KEY` and `REQUESTY_BASE_URL` handling via `resolve_requesty_base_url`, default model `openai/gpt-4o-mini`, and a model list seeded from Requesty managed policy ids (`GET /v1/models/managed`, verified live on 2026-09-11). Full `<vendor>/<model>` catalog ids work as well.
- `registry.py`: `requesty` `ProviderFamilySpec` and env key slot. `env_keys.py`: `REQUESTY_API_KEY`.
- `llm_picker.py`: `Requesty` in `SUPPORTED_PROVIDERS`, `requesty` alias, dispatch branch that resolves the key, default model and base URL and routes to `OpenAILike`.
- `cli/main.py`: help strings for `--provider`, `--base_url` and `configure --provider`.
- Docs: provider and environment variable tables in `README.md`, `SKILL.md`, `docs/quickstart.mdx`, `docs/guides/cli.mdx` (with a region table including the EU endpoint) and `docs/sdk/configuration.mdx`.
- Tests: `tests/test_requesty_configuration.py` (17 tests mirroring `test_minimax_configuration.py`) covering the registry entry, setup profile generation, key source resolution, picker defaults and base URL overrides.

No new dependency: Requesty rides on the always installed `llama-index-llms-openai-like`. Not added to any automatic provider preference.

## Validation

- `ruff check` and `black --check` clean on all touched files.
- Full test suite: 967 passed. The only failure, `test_legacy_minimax_profile_warns_once_without_migration`, fails identically on clean `main` and is unrelated.
- Live check: `load_llm("Requesty", model="openai/gpt-4o-mini")` (the `mobilerun run --provider Requesty` path) and the `configure` profile path (`apply_selection_to_roles` to `load_llms_from_profiles`) both completed a real chat call. Every model id in the menu was confirmed present in the live `/v1/models/managed` and `/v1/models` catalogs.

Disclosure: I work at Requesty. Happy to adjust anything to match project conventions.
